### PR TITLE
proposal for chaining

### DIFF
--- a/src/Functional/Chain.php
+++ b/src/Functional/Chain.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Functional;
+
+function chain($collection)
+{
+    Exceptions\InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
+    
+    return new Chaining($collection);
+}
+
+class Chaining
+{
+    protected $collection;
+    
+    public function __construct($collection)
+    {
+        Exceptions\InvalidArgumentException::assertCollection($collection, __METHOD__, 1);
+        
+        $this->collection = $collection;
+    }
+    
+    public function __call($name, $arguments) 
+    {
+        $collection = call_user_func_array('Functional\\' . $name, array_merge(array($this->collection), $arguments));
+        return new static($collection);
+    }
+    
+    public function _()
+    {
+        return $this->collection;
+    }
+}

--- a/src/Functional/_import.php
+++ b/src/Functional/_import.php
@@ -58,4 +58,6 @@ if (!extension_loaded('functional')) {
     require_once $basePath . 'Reject.php';
     /** @var Functional\select() */
     require_once $basePath . 'Select.php';
+    /** @var Functional\select() */
+    require_once $basePath . 'Chain.php';
 }


### PR DESCRIPTION
Hey there,

actually not really a request for merging, more of an idea (dont know how far your chaining branch is) … recently I played around with cassandra and the php client library has a response format which needs some transformation. Functional PHP comes in handy here but with chaining it would be even better. I implemented an idea that works at least for map() maybe for some other use cases, too. Its a pretty naive implementation.

Here is a code sample of what is possible with this addition:

``` php
use Functional as F;

class SampleClass
{
    public $id;

    public $name;

    public function __construct(array $data)
    {
        $this->id = $data['id'];
        $this->name = $data['name'];
    }
}

class SampleApiResponseObject
{
    public $value;

    public function __construct($value)
    {
        $this->value = $value;
    }
}


// ------

$res = array(
    new SampleApiResponseObject('{"id":1,"name":"name 1"}'),
    new SampleApiResponseObject('{"id":2,"name":"name 2"}'),
);


$chained = F\Chain($res)->map(function(SampleApiResponseObject $obj) {
    return json_decode($obj->value, true);
})->map(function(array $data) {
    return new SampleClass($data);
})->_(); // <-- a bit ugly for ending chain
         // would have rather used __invoke, but ->map(function(array $data) { ... })(); results in a syntax error...


$unchained = F\map($res, function(SampleApiResponseObject $obj) {
    return json_decode($obj->value, true);
});

$unchained = F\map($unchained, function(array $data) {
    return new SampleClass($data);
});


var_dump($chained);
var_dump($unchained);
```
