### PR TITLE
added userland implementation for invoke_if()

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ if (F\every($users, function($user, $collectionKey, $collection) {return $user->
 ```
 
 
+### Functional\invoke_if()
+
+``mixed Functional\invoke_if(mixed $object, string $methodName[, array $methodArguments, mixed $defaultValue])``
+
+```php
+<?php
+use Functional as F;
+
+// if $user is an object and has a public method getId() it is returned,
+// otherwise default value 0 (4th argument) is used
+$userId = F\invoke_if($user, 'getId', array(), 0);
+```
+
+
 ### Functional\some()
 
 ``bool Functional\some(array|Traversable $collection, callable $callback)``

--- a/src/Functional/InvokeIf.php
+++ b/src/Functional/InvokeIf.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright (C) 2011 - 2012 by Lars Strojny <lstrojny@php.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+/**
+ * Calls the method named by $methodName on $object. Any extra arguments passed to invoke_if will be
+ * forwarded on to the method invocation. If $method is not callable on $object, $defaultValue is returned.
+ *
+ * @param mixed $object
+ * @param string $methodName
+ * @param array $methodArguments
+ * @param mixed $defaultValue
+ * @return mixed
+ */
+function invoke_if($object, $methodName, array $methodArguments = array(), $defaultValue = null)
+{
+    $callback = array($object, $methodName);
+    if (is_callable($callback)) {
+        return call_user_func_array($callback, $methodArguments);
+    }
+
+    return $defaultValue;
+}

--- a/src/Functional/_import.php
+++ b/src/Functional/_import.php
@@ -34,6 +34,7 @@ if (!extension_loaded('functional')) {
     require_once $basePath . 'Flatten.php';
     require_once $basePath . 'Group.php';
     require_once $basePath . 'Invoke.php';
+    require_once $basePath . 'InvokeIf.php';
     require_once $basePath . 'InvokeFirst.php';
     require_once $basePath . 'InvokeLast.php';
     require_once $basePath . 'Last.php';

--- a/tests/unit/Functional/InvokeIfTest.php
+++ b/tests/unit/Functional/InvokeIfTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright (C) 2011 - 2012 by Lars Strojny <lstrojny@php.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+use ArrayIterator;
+
+class InvokeIfTest extends AbstractTestCase
+{
+    function setUp()
+    {
+        parent::setUp(array('Functional\\invoke_if'));
+    }
+
+    function test()
+    {
+        $this->assertSame('methodValue', invoke_if($this, 'method', array(), 'defaultValue'));
+        $this->assertSame('methodValue', invoke_if($this, 'method'));
+        $arguments = array(1, 2, 3);
+        $this->assertSame($arguments, invoke_if($this, 'returnArguments', $arguments));
+        $this->assertNull(invoke_if($this, 'someMethod', $arguments));
+        $this->assertNull(invoke_if(1, 'someMethod', $arguments));
+        $this->assertNull(invoke_if(null, 'someMethod', $arguments));
+    }
+
+    function testReturnDefaultValueUsed()
+    {
+        $instance = new \stdClass();
+        $this->assertSame('defaultValue', invoke_if($instance, 'someMethod', array(), 'defaultValue'));
+        $this->assertSame($instance, invoke_if($this, 'someMethod', array(), $instance));
+        $this->assertNull(invoke_if($this, 'someMethod', array(), null));
+    }
+
+    function method()
+    {
+        return 'methodValue';
+    }
+
+    function returnArguments()
+    {
+        return func_get_args();
+    }
+}


### PR DESCRIPTION
This is the userland implementation for `invoke_if()` which can be used to call a method with or without arguments on an object. If that method does not exist or the object is null, a default value can be used.
