### PR TITLE
Multiple fn version of partition()

### DIFF
--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -633,17 +633,26 @@ Calculates the average of all numeric elements
 
 
 ## partition()
-Splits a collection into two by callback. Truthy values come first
+Splits a collection into two or more by callback(s). For each element,
+each partition is called in turn, until one returns a truthy value, or
+all have been called. Each element is placed in the partition for
+first callback it passes; if no callback succeeds, it is placed in the
+final partition.
 
-``array Functional\partition(array|Traversable $collection, callable $callback)``
+``array Functional\partition(array|Traversable $collection, callable $callback ...)``
 
 ```php
 <?php
 use function Functional\partition;
 
-list($admins, $users) = partition($collection, function($user) {
-    return $user->isAdmin();
-});
+list($admins, $guests, $users) = partition(
+    $collection,
+    function($user) {
+        return $user->isAdmin();
+    },
+    function($user) {
+        return $user->isGuest();
+    });
 ```
 
 

--- a/tests/Functional/PartitionTest.php
+++ b/tests/Functional/PartitionTest.php
@@ -49,6 +49,24 @@ class PartitionTest extends AbstractTestCase
         $this->assertSame([['k2' => 'val2'], ['k1' => 'val1', 'k3' => 'val3']], partition($this->hashIterator, $fn));
     }
 
+    public function testMultiFn()
+    {
+        $fn1 = function($v, $k, $collection) {
+            InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
+            return is_int($k) ? ($k === 1) : ($v[3] === '2');
+        };
+
+        $fn2 = function($v, $k, $collection) {
+            InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
+            return is_int($k) ? ($k === 2) : ($v[3] === '3');
+        };
+
+        $this->assertSame([[1 => 'value2'], [2 => 'value3'], [0 => 'value1']], partition($this->list, $fn1, $fn2));
+        $this->assertSame([[1 => 'value2'], [2 => 'value3'], [0 => 'value1']], partition($this->listIterator, $fn1, $fn2));
+        $this->assertSame([['k2' => 'val2'], ['k3' => 'val3'], ['k1' => 'val1']], partition($this->hash, $fn1, $fn2));
+        $this->assertSame([['k2' => 'val2'], ['k3' => 'val3'], ['k1' => 'val1']], partition($this->hashIterator, $fn1, $fn2));
+    }
+
     public function testExceptionIsThrownInArray()
     {
         $this->setExpectedException('DomainException', 'Callback exception');


### PR DESCRIPTION
Partition() currently only accepts one predicate function and splits an
array in to two partitions, putting elements which pass in the first,
and those which fail in the second.

Partition() should accept n predicate functions, create n+1 partitions,
and place each element in the partition of the first predicate it
matches, with unmatched ones in the last.

In the case of single predicate function the behavior should be
unchanged.