### PR TITLE
ReduceLeft and ReduceRight: Changed return type to 'mixed' from 'array'

### DIFF
--- a/src/Functional/ReduceLeft.php
+++ b/src/Functional/ReduceLeft.php
@@ -29,7 +29,7 @@ use Traversable;
  * @param Traversable|array $collection
  * @param callable $callback
  * @param mixed $initial
- * @return array
+ * @return mixed
  */
 function reduce_left($collection, callable $callback, $initial = null)
 {

--- a/src/Functional/ReduceRight.php
+++ b/src/Functional/ReduceRight.php
@@ -29,7 +29,7 @@ use Traversable;
  * @param Traversable|array $collection
  * @param callable $callback
  * @param mixed $initial
- * @return array
+ * @return mixed
  */
 function reduce_right($collection, callable $callback, $initial = null)
 {


### PR DESCRIPTION
Return type should be the same as the type of `$initial`, which is `mixed`