### PR TITLE
Implement currying

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,8 @@
             "src/Functional/CompareObjectHashOn.php",
             "src/Functional/Compose.php",
             "src/Functional/Contains.php",
+            "src/Functional/Curry.php",
+            "src/Functional/CurryN.php",
             "src/Functional/Difference.php",
             "src/Functional/DropFirst.php",
             "src/Functional/DropLast.php",

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -397,7 +397,7 @@ $registeredUsers = select($users, partial_method('isRegistered'));
 
 # Currying
 
-Currying is similar to and often confused with partial application. But instead of bindind parameters to some value and returning a new function, a curryied function will take one parameter on each call and return a new function until all parameters are bound.
+Currying is similar to and often confused with partial application. But instead of binding parameters to some value and returning a new function, a curryied function will take one parameter on each call and return a new function until all parameters are bound.
 
 Currying can be seen as partially applying one parameter after the other.
 
@@ -419,7 +419,7 @@ The difference becomes more salient with functions taking more than two paramete
 use function Functional\curry;
 
 function add($a, $b, $c, $d) {
-	return $a + $b + $c + $d;
+    return $a + $b + $c + $d;
 }
 
 $curryedAdd = curry('add');
@@ -436,7 +436,7 @@ Since PHP allows for optional parameters, you can decide if you want to curry th
 use function Functional\curry;
 
 function add($a, $b, $c = 10) {
-	return $a + $b + $c;
+    return $a + $b + $c;
 }
 
 // Curry only required parameters, the default, $c will always be 10
@@ -452,7 +452,7 @@ Starting with PHP7 and the implementation of the ["Uniform variable syntax"](htt
 use function Functional\curry;
 
 function add($a, $b, $c, $d) {
-	return $a + $b + $c + $d;
+    return $a + $b + $c + $d;
 }
 
 $curryedAdd = curry('add');
@@ -467,7 +467,7 @@ $curryedAdd(10)(5)(27)(10); // -> 52
 use function Functional\curry;
 
 function add($a, $b, $c, $d) {
-	return $a + $b + $c + $d;
+    return $a + $b + $c + $d;
 }
 
 $curryedAdd = curry_n(2, 'add');

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -23,6 +23,9 @@
   - [partial_left() & partial_right()](#partial_left--partial_right)
   - [partial_any()](#partial_any)
   - [partial_method()](#partial_method)
+- [Currying](#currying)
+  - [curry()](#curry)
+  - [curry_n()](#curry_n)
 - [Access functions](#access-functions)
   - [with()](#with)
   - [invoke_if()](#invoke_if)
@@ -391,6 +394,90 @@ use function Functional\partial_method;
 $users = [new User(), new User()];
 $registeredUsers = select($users, partial_method('isRegistered'));
 ```
+
+# Currying
+
+Currying is similar to and often confused with partial application. But instead of bindind parameters to some value and returning a new function, a curryied function will take one parameter on each call and return a new function until all parameters are bound.
+
+Currying can be seen as partially applying one parameter after the other.
+
+## curry
+
+If we revisit the example used for partial application, the curryied version would be :
+
+```php
+use function Functional\curry;
+
+$curryedSubtractor = curry($subtractor);
+$subtractFrom10 = $curryedSubtractor(10)
+$subtractFrom10(20); // -> -10
+```
+
+The difference becomes more salient with functions taking more than two parameters :
+ 
+```php
+use function Functional\curry;
+
+function add($a, $b, $c, $d) {
+	return $a + $b + $c + $d;
+}
+
+$curryedAdd = curry('add');
+
+$add10 = $curryedAdd(10);
+$add15 = $add10(5);
+$add42 = $add15(27);
+$add42(10); // -> 52
+```
+
+Since PHP allows for optional parameters, you can decide if you want to curry them or not. The default is to not curry them.
+
+```php
+use function Functional\curry;
+
+function add($a, $b, $c = 10) {
+	return $a + $b + $c;
+}
+
+// Curry only required parameters, the default, $c will always be 10
+$curryedAdd = curry('add', true);
+
+// This time, 3 parameters will be curryied.
+$curryedAddWithOptional = curry('add', false);
+```
+
+Starting with PHP7 and the implementation of the ["Uniform variable syntax"](https://wiki.php.net/rfc/uniform_variable_syntax), you can greatly simpliy the usage of curryied functions.
+
+```php
+use function Functional\curry;
+
+function add($a, $b, $c, $d) {
+	return $a + $b + $c + $d;
+}
+
+$curryedAdd = curry('add');
+$curryedAdd(10)(5)(27)(10); // -> 52
+```
+
+## curry_n
+
+`curry` uses reflection to determine the number of arguments, which can be slow depdening on your requirements. Also, you might want to curry only the first parameters, or your function expects a variable number of parameters. In all cases, you can use `curry_n` instead.
+
+```php
+use function Functional\curry;
+
+function add($a, $b, $c, $d) {
+	return $a + $b + $c + $d;
+}
+
+$curryedAdd = curry_n(2, 'add');
+
+$add10 = $curryedAdd(10);
+$add15 = $add10(5);
+$add15(27, 10); // -> 52
+```
+
+Note that if you given a parameter bigger than the real number of parameters of your function, all extraneous parameters will simply be passed but ignored by the original function.
 
 # Access functions
 

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -32,7 +32,16 @@ namespace Functional;
  */
 function curry(callable $function, $required = true)
 {
-    $reflection = new \ReflectionFunction($function);
+    if(is_string($function) && strpos($function, '::', 1) !== false) {
+        $reflection = new \ReflectionMethod($function);
+    } else if(is_array($function) && count($function) == 2) {
+        $reflection = new \ReflectionMethod($function[0], $function[1]);
+    } else if(is_object($function) && method_exists($function, '__invoke')) {
+        $reflection = new \ReflectionMethod($function, '__invoke');
+    } else {
+        $reflection = new \ReflectionFunction($function);
+    }
+
     $count = $required ?
         $reflection->getNumberOfRequiredParameters() :
         $reflection->getNumberOfParameters();

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (C) 2011-2016 by Gilles Crettenand <gilles@crettenand.info>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+/**
+ * Return a curryied version of the given function. You can decide if you also
+ * want to curry optional parameters or not.
+ *
+ * @param callable $function the function to curry
+ * @param bool $required curry optional parameters ?
+ * @return callable a curryied version of the given function
+ */
+function curry(callable $function, $required = true)
+{
+    $reflection = new \ReflectionFunction($function);
+    $count = $required ?
+        $reflection->getNumberOfRequiredParameters() :
+        $reflection->getNumberOfParameters();
+
+    return curry_n($count, $function);
+}

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -37,7 +37,7 @@ function curry(callable $function, $required = true)
 {
     if (is_string($function) && strpos($function, '::', 1) !== false) {
         $reflection = new ReflectionMethod($function);
-    } elseif (is_array($function) && count($function) == 2) {
+    } elseif (is_array($function) && count($function) === 2) {
         $reflection = new ReflectionMethod($function[0], $function[1]);
     } elseif (is_object($function) && method_exists($function, '__invoke')) {
         $reflection = new ReflectionMethod($function, '__invoke');

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -24,6 +24,7 @@ namespace Functional;
 
 use ReflectionMethod;
 use ReflectionFunction;
+use Closure;
 
 /**
  * Return a curryied version of the given function. You can decide if you also
@@ -35,14 +36,18 @@ use ReflectionFunction;
  */
 function curry(callable $function, $required = true)
 {
-    if (is_string($function) && strpos($function, '::', 1) !== false) {
-        $reflection = new ReflectionMethod($function);
-    } elseif (is_array($function) && count($function) === 2) {
-        $reflection = new ReflectionMethod($function[0], $function[1]);
-    } elseif (is_object($function) && method_exists($function, '__invoke')) {
-        $reflection = new ReflectionMethod($function, '__invoke');
+    if(method_exists('\Closure','fromCallable')) {
+        $reflection = new ReflectionFunction(Closure::fromCallable($function));
     } else {
-        $reflection = new ReflectionFunction($function);
+        if (is_string($function) && strpos($function, '::', 1) !== false) {
+            $reflection = new ReflectionMethod($function);
+        } elseif (is_array($function) && count($function) === 2) {
+            $reflection = new ReflectionMethod($function[0], $function[1]);
+        } elseif (is_object($function) && method_exists($function, '__invoke')) {
+            $reflection = new ReflectionMethod($function, '__invoke');
+        } else {
+            $reflection = new ReflectionFunction($function);
+        }
     }
 
     $count = $required ?

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -36,7 +36,7 @@ use Closure;
  */
 function curry(callable $function, $required = true)
 {
-    if(method_exists('\Closure','fromCallable')) {
+    if (method_exists('Closure','fromCallable')) {
         $reflection = new ReflectionFunction(Closure::fromCallable($function));
     } else {
         if (is_string($function) && strpos($function, '::', 1) !== false) {

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -22,6 +22,9 @@
  */
 namespace Functional;
 
+use ReflectionMethod;
+use ReflectionFunction;
+
 /**
  * Return a curryied version of the given function. You can decide if you also
  * want to curry optional parameters or not.
@@ -32,14 +35,14 @@ namespace Functional;
  */
 function curry(callable $function, $required = true)
 {
-    if(is_string($function) && strpos($function, '::', 1) !== false) {
-        $reflection = new \ReflectionMethod($function);
-    } else if(is_array($function) && count($function) == 2) {
-        $reflection = new \ReflectionMethod($function[0], $function[1]);
-    } else if(is_object($function) && method_exists($function, '__invoke')) {
-        $reflection = new \ReflectionMethod($function, '__invoke');
+    if (is_string($function) && strpos($function, '::', 1) !== false) {
+        $reflection = new ReflectionMethod($function);
+    } elseif (is_array($function) && count($function) == 2) {
+        $reflection = new ReflectionMethod($function[0], $function[1]);
+    } elseif (is_object($function) && method_exists($function, '__invoke')) {
+        $reflection = new ReflectionMethod($function, '__invoke');
     } else {
-        $reflection = new \ReflectionFunction($function);
+        $reflection = new ReflectionFunction($function);
     }
 
     $count = $required ?

--- a/src/Functional/CurryN.php
+++ b/src/Functional/CurryN.php
@@ -40,7 +40,7 @@ function curry_n($count, callable $function)
             $arguments = array_merge($arguments, $newArguments);
 
             if ($count <= count($arguments)) {
-                return $function(...$arguments);
+                return call_user_func_array($function, $arguments);
             }
 
             return $accumulator($arguments);

--- a/src/Functional/CurryN.php
+++ b/src/Functional/CurryN.php
@@ -39,7 +39,7 @@ function curry_n($count, callable $function)
         return function($a) use($count, $function, $arguments, $accumulator) {
             array_push($arguments, $a);
 
-            if($count == count($arguments)) {
+            if($count <= count($arguments)) {
                 return $function(...$arguments);
             }
 

--- a/src/Functional/CurryN.php
+++ b/src/Functional/CurryN.php
@@ -35,11 +35,11 @@ namespace Functional;
  */
 function curry_n($count, callable $function)
 {
-    $accumulator = function(array $arguments) use($count, $function, &$accumulator) {
-        return function(...$newArguments) use($count, $function, $arguments, $accumulator) {
+    $accumulator = function (array $arguments) use ($count, $function, &$accumulator) {
+        return function (...$newArguments) use ($count, $function, $arguments, $accumulator) {
             $arguments = array_merge($arguments, $newArguments);
 
-            if($count <= count($arguments)) {
+            if ($count <= count($arguments)) {
                 return $function(...$arguments);
             }
 

--- a/src/Functional/CurryN.php
+++ b/src/Functional/CurryN.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (C) 2011-2016 by Gilles Crettenand <gilles@crettenand.info>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+/**
+ * Return a version of the given function where the $count first arguments are curryied.
+ *
+ * No check is made to verify that the given argument count is either too low or too high.
+ * If you give a smaller number you will have an error when calling the given function. If
+ * you give a higher number, arguments will simply be ignored.
+ *
+ * @param int $count number of arguments you want to curry
+ * @param callable $function the function you want to curry
+ * @return callable a curryied version of the given function
+ */
+function curry_n($count, callable $function)
+{
+    $accumulator = function(array $arguments) use($count, $function, &$accumulator) {
+        return function($a) use($count, $function, $arguments, $accumulator) {
+            array_push($arguments, $a);
+
+            if($count == count($arguments)) {
+                return $function(...$arguments);
+            }
+
+            return $accumulator($arguments);
+        };
+    };
+
+    return $accumulator([]);
+}

--- a/src/Functional/CurryN.php
+++ b/src/Functional/CurryN.php
@@ -36,8 +36,8 @@ namespace Functional;
 function curry_n($count, callable $function)
 {
     $accumulator = function(array $arguments) use($count, $function, &$accumulator) {
-        return function($a) use($count, $function, $arguments, $accumulator) {
-            array_push($arguments, $a);
+        return function(...$newArguments) use($count, $function, $arguments, $accumulator) {
+            $arguments = array_merge($arguments, $newArguments);
 
             if($count <= count($arguments)) {
                 return $function(...$arguments);

--- a/tests/Functional/CurryNTest.php
+++ b/tests/Functional/CurryNTest.php
@@ -23,7 +23,6 @@
 namespace Functional\Tests;
 
 use function Functional\curry_n;
-use function Functional\id;
 use function Functional\invoker;
 
 use DateTime;
@@ -32,13 +31,15 @@ function add($a, $b, $c, $d) {
     return $a + $b + $c + $d;
 }
 
-class Adder {
+class Adder
+{
     public static function static_add($a, $b, $c, $d)
     {
         return add($a, $b, $c, $d);
     }
 
-    public function add($a, $b, $c, $d) {
+    public function add($a, $b, $c, $d)
+    {
         return static::static_add($a, $b, $c, $d);
     }
 
@@ -50,8 +51,7 @@ class Adder {
 
 class CurryNTest extends AbstractPartialTestCase
 {
-
-    protected function _getCurryiedCallable($callback, $params, $required)
+    protected function getCurryiedCallable($callback, $params, $required)
     {
         return curry_n(count($params), $callback);
     }
@@ -61,11 +61,11 @@ class CurryNTest extends AbstractPartialTestCase
      */
     public function testCallbackTypes($callback, $params, $expected, $required, $transformer = null)
     {
-        if(is_null($transformer)) {
+        if (is_null($transformer)) {
             $transformer = 'Functional\id';
         }
 
-        $curryied = $this->_getCurryiedCallable($callback, $params, $required);
+        $curryied = $this->getCurryiedCallable($callback, $params, $required);
 
         $this->assertEquals($transformer($expected), $transformer(call_user_func_array($curryied, $params)));
 
@@ -75,7 +75,7 @@ class CurryNTest extends AbstractPartialTestCase
 
             $curryied = $curryied($p);
 
-            if(count($params) > 0) {
+            if (count($params) > 0) {
                 $this->assertTrue(is_callable($curryied));
                 $this->assertEquals($transformer($expected), $transformer(call_user_func_array($curryied, $params)));
             } else {

--- a/tests/Functional/CurryNTest.php
+++ b/tests/Functional/CurryNTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (C) 2011-2016 by Gilles Crettenand <gilles@crettenand.info>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional\Tests;
+
+use function Functional\curry_n;
+
+class CurryNTest extends AbstractPartialTestCase
+{
+    public function testWithArgs()
+    {
+        $ratio = curry_n(4, $this->ratio());
+
+        $a = $ratio(8);
+        $this->assertTrue(is_callable($a));
+
+        $b = $a(2);
+        $this->assertTrue(is_callable($b));
+
+        $c = $b(2);
+        $this->assertTrue(is_callable($c));
+
+        $this->assertSame(1, $c(2));
+    }
+}

--- a/tests/Functional/CurryTest.php
+++ b/tests/Functional/CurryTest.php
@@ -24,18 +24,10 @@ namespace Functional\Tests;
 
 use function Functional\curry;
 
-class CurryTest extends AbstractTestCase
+class CurryTest extends CurryNTest
 {
-    public function testWithArgs()
+    protected function _getCurryiedCallable($callback, $params, $required)
     {
-        $add = function($a, $b) {
-            return $a + $b;
-        };
-        $addCurryied = curry($add);
-
-        $a = $addCurryied(10);
-        $this->assertTrue(is_callable($a));
-
-        $this->assertSame(15, $a(5));
+        return curry($callback, $required);
     }
 }

--- a/tests/Functional/CurryTest.php
+++ b/tests/Functional/CurryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (C) 2011-2016 by Gilles Crettenand <gilles@crettenand.info>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional\Tests;
+
+use function Functional\curry;
+
+class CurryTest extends AbstractTestCase
+{
+    public function testWithArgs()
+    {
+        $add = function($a, $b) {
+            return $a + $b;
+        };
+        $addCurryied = curry($add);
+
+        $a = $addCurryied(10);
+        $this->assertTrue(is_callable($a));
+
+        $this->assertSame(15, $a(5));
+    }
+}

--- a/tests/Functional/CurryTest.php
+++ b/tests/Functional/CurryTest.php
@@ -26,7 +26,7 @@ use function Functional\curry;
 
 class CurryTest extends CurryNTest
 {
-    protected function _getCurryiedCallable($callback, $params, $required)
+    protected function getCurryiedCallable($callback, $params, $required)
     {
         return curry($callback, $required);
     }


### PR DESCRIPTION
Add two functions to allow for currying.

I searched the history of pull request and issues and found an old issue discussion partial application and currying. It seems that partial application made its way into the repository but not currying.

Here is a possible implementation for currying.

The reason to have both `curry` and `curry_n` is explained in the documentation.

I hope this can make it in the lib :)

At your disposition if you have any feedback.