### PR TITLE
Test against the current hhvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,16 @@ sudo: false
 php:
   - 5.6
   - 7.0
+  - 7.1
   - nightly
-  - hhvm
 
 matrix:
+  fast_finish: true
+  include:
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Until the next stable image update after 2016-12-01
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
You are currently testing on an old EOL version of HHVM 3.6.6 (as HHVM no longer releases for precise which is used by Travis)

This PR provides the current HHVM version (3.15.3 as of this PR) and will track with each release (i.e. will be 3.16 when 3.16 is released until HHVM no longer releases for Trusty).

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/