### PR TITLE
Compose functions from right to left.

### DIFF
--- a/src/Functional/Compose.php
+++ b/src/Functional/Compose.php
@@ -35,7 +35,7 @@ use function Functional\id;
 function compose(...$functions)
 {
     return array_reduce(
-        $functions,
+        array_reverse($functions),
         function ($carry, $item) {
             return function ($x) use ($carry, $item) {
                 return $item($carry($x));


### PR DESCRIPTION
If functions execute from left to right, then it's technically a pipe function. Unfortunately, this would be a breaking change to anyone using the `compose` function from the library upon this update. 