### PR TITLE
Add tap()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
             "src/Functional/Sort.php",
             "src/Functional/Sum.php",
             "src/Functional/SuppressError.php",
+            "src/Functional/Tap.php",
             "src/Functional/Tail.php",
             "src/Functional/TailRecursion.php",
             "src/Functional/True.php",

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -62,6 +62,7 @@
 - [Miscellaneous](#miscellaneous)
   - [const_function()](#const_function)
   - [id()](#id)
+  - [tap()](#tap)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1012,3 +1013,17 @@ use function Functional\id;
 
 1 === id(1);
 ```
+
+## tap()
+``mixed tap(mixed $value, callable $callback)``
+
+Call the given Closure with the given value, then return the value.
+
+```php
+<?php 
+use function Functional\tap;
+tap(User::create('John Doe'), function (User $user) {
+    UserService::sendWelcomeEmail($user);
+})->login();
+```
+

--- a/src/Functional/Tap.php
+++ b/src/Functional/Tap.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright (C) 2011-2017 by Lars Strojny <lstrojny@php.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+/**
+ * Call the given Closure with the given value, then return the value.
+ *
+ * @param  mixed  $value
+ * @param  callable $callback
+ * @return mixed
+ */
+function tap ($value, callable $callback) {
+	$callback($value);
+
+	return $value;
+}

--- a/src/Functional/Tap.php
+++ b/src/Functional/Tap.php
@@ -29,8 +29,8 @@ namespace Functional;
  * @param  callable $callback
  * @return mixed
  */
-function tap ($value, callable $callback) {
-	$callback($value);
+function tap($value, callable $callback) {
+    $callback($value);
 
-	return $value;
+    return $value;
 }

--- a/tests/Functional/TapTest.php
+++ b/tests/Functional/TapTest.php
@@ -26,27 +26,27 @@ use function Functional\tap;
 
 class TapTest extends AbstractTestCase
 {
-	public function setUp()
-	{
-		parent::setUp();
-	}
+    public function setUp()
+    {
+        parent::setUp();
+    }
 
-	public function testPassNonCallable()
-	{
-		$this->expectArgumentError('Argument 2 passed to Functional\tap() must be callable');
-		tap('foo', 'undefinedFunction');
-	}
+    public function testPassNonCallable()
+    {
+        $this->expectArgumentError('Argument 2 passed to Functional\tap() must be callable');
+        tap('foo', 'undefinedFunction');
+    }
 
-	public function testTap()
-	{
-		$foo = new \stdClass();
-		$foo->bar = 'baz';
+    public function testTap()
+    {
+        $input = new \stdClass();
+        $input->property = 'foo';
 
-		$tapped = tap($foo, function ($o) {
-			$o->bar = 'qux';
-		});
+        $output = tap($input, function ($o) {
+            $o->property = 'bar';
+        });
 
-		self::assertSame($foo, $tapped);
-		self::assertSame('qux', $foo->bar);
-	}
+        self::assertSame($input, $output);
+        self::assertSame('bar', $input->property);
+    }
 }

--- a/tests/Functional/TapTest.php
+++ b/tests/Functional/TapTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (C) 2011-2017 by Lars Strojny <lstrojny@php.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional\Tests;
+
+use function Functional\tap;
+
+class TapTest extends AbstractTestCase
+{
+	public function setUp()
+	{
+		parent::setUp();
+	}
+
+	public function testPassNonCallable()
+	{
+		$this->expectArgumentError('Argument 2 passed to Functional\tap() must be callable');
+		tap('foo', 'undefinedFunction');
+	}
+
+	public function testTap()
+	{
+		$foo = new \stdClass();
+		$foo->bar = 'baz';
+
+		$tapped = tap($foo, function ($o) {
+			$o->bar = 'qux';
+		});
+
+		self::assertSame($foo, $tapped);
+		self::assertSame('qux', $foo->bar);
+	}
+}


### PR DESCRIPTION
`tap()` calls the given `$callback` with the given `$value`, which, in quite a few cases, makes the code read more fluent and "functional":

```php
tap(User::create('John Doe'), function (User $user) {
    UserService::sendWelcomeEmail($user);
})->login();

// or

tap(DisposableEmail::create('From Nigerian Prince with luv'), function (Email $email) {
    EmailManager::send($email);
})->destroy();
```

This function is inspired by [Laravel](https://medium.com/@taylorotwell/tap-tap-tap-1fc6fc1f93a6), which is in turn inspired by [Ruby](https://medium.com/aviabird/ruby-tap-that-method-90c8a801fd6a).