### PR TITLE
Implement sort_by

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
             "src/Functional/SequenceLinear.php",
             "src/Functional/Some.php",
             "src/Functional/Sort.php",
+            "src/Functional/SortBy.php",
             "src/Functional/Sum.php",
             "src/Functional/SuppressError.php",
             "src/Functional/Tap.php",

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -17,6 +17,7 @@
   - [truthy() & falsy()](#truthy--falsy)
   - [contains()](#contains)
   - [sort()](#sort)
+  - [sort_by()](#sort_by)
   - [Other:](#other)
 - [Partial application](#partial-application)
   - [Introduction](#introduction)
@@ -264,6 +265,28 @@ sort($collection, function($user1, $user2) {
 
     return ($user1->getAge() < $user2->getAge()) ? -1 : 1;
 });
+```
+
+## sorty_by()
+Sorts a collection by a value of some function
+
+```php
+<?php
+use function Functional\sort_by;
+
+// Sorts a collection by the length of its elements
+sort_by(
+    ['bear', 'aardvark', 'cat'],
+    function($element, $collection) { 
+        return strlen($element);
+    }
+); // Returns ['cat', 'bear', 'aardvark']
+sort_by(
+    ['bear', 'aardvark', 'cat'],
+    function($element, $collection) { 
+        return -strlen($element);
+    }
+); // Returns ['aardvark', 'bear', 'cat']
 ```
 
 

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -268,7 +268,7 @@ sort($collection, function($user1, $user2) {
 ```
 
 ## sorty_by()
-Sorts a collection by a value of some function
+Sorts a collection by a value of some function, optionally preserving array keys
 
 ```php
 <?php

--- a/src/Functional/Functional.php
+++ b/src/Functional/Functional.php
@@ -385,6 +385,11 @@ final class Functional
     const sort = '\Functional\sort';
 
     /**
+     * @see \Functional\sort_by
+     */
+    const sort_by = '\Functional\sort_by';
+
+    /**
      * @see \Functional\sum
      */
     const sum = '\Functional\sum';

--- a/src/Functional/SortBy.php
+++ b/src/Functional/SortBy.php
@@ -37,7 +37,7 @@ function sort_by($collection, callable $getProperty, $preserveKeys = false)
 {
     return sort(
         $collection,
-        function($left, $right, $collection) use ($functionName, $getProperty) {
+        function($left, $right, $collection) use ($getProperty) {
             return $getProperty($left, $collection) - $getProperty($right, $collection);
         },
         $preserveKeys

--- a/src/Functional/SortBy.php
+++ b/src/Functional/SortBy.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright (C) 2011-2017 by Lars Strojny <lstrojny@php.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+use Traversable;
+
+/**
+ * Sorts a collection by a value of some function of its elements
+ *
+ * @param Traversable|array $collection
+ * @param callable $getProperty function($element, $collection) returns int
+ * @param bool $preserveKeys
+ * @see sort()
+ * @return array
+ */
+function sort_by($collection, callable $getProperty, $preserveKeys = false)
+{
+    $functionName = __FUNCTION__;
+    return sort(
+        $collection,
+        function($left, $right, $collection) use ($functionName, $getProperty) {
+            return $getProperty($left, $collection) - $getProperty($right, $collection);
+        },
+        $preserveKeys
+    );
+}

--- a/src/Functional/SortBy.php
+++ b/src/Functional/SortBy.php
@@ -35,7 +35,6 @@ use Traversable;
  */
 function sort_by($collection, callable $getProperty, $preserveKeys = false)
 {
-    $functionName = __FUNCTION__;
     return sort(
         $collection,
         function($left, $right, $collection) use ($functionName, $getProperty) {

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -78,5 +78,4 @@ class SortByTest extends AbstractTestCase
             )
         );
     }
-
 }

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -85,8 +85,8 @@ class SortByTest extends AbstractTestCase
             ],
             sort_by(
                 $this->list,
-                function($e, $key, $collection) {
-                    return strlen($collection[($key + 1) % count($collection)]);
+                function($e, $collection) {
+                    return strlen($collection[(array_search($e, $collection) + 1) % count($collection)]);
                 },
                 false
             )

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -74,4 +74,22 @@ class SortByTest extends AbstractTestCase
             )
         );
     }
+
+    public function testCollectionArgument()
+    {
+        $this->assertSame(
+            [
+                0 => 'aardvark',
+                1 => 'cat',
+                2 => 'bear',
+            ],
+            sort_by(
+                $this->list,
+                function($e, $key, $collection) {
+                    return strlen($collection[($key + 1) % count($collection)]);
+                },
+                false
+            )
+        );
+    }
 }

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -35,17 +35,13 @@ class SortByTest extends AbstractTestCase
         $this->listIterator = new ArrayIterator($this->list);
         $this->hash = ['c' => 'cat', 'b' => 'bear', 'a' => 'aardvark'];
         $this->hashIterator = new ArrayIterator($this->hash);
-        $this->getProperty =
-            function($e, $_) {
-                return strlen($e);
-            };
     }
 
     public function testPreserveKeys()
     {
         $this->assertSame(
             [1 => 'cat', 0 => 'bear', 2 => 'aardvark'],
-            sort_by($this->list, $this->getProperty, true)
+            sort_by($this->list, function($e) { return strlen($e); },  true)
         );
     }
 
@@ -57,7 +53,7 @@ class SortByTest extends AbstractTestCase
                 1 => 'bear',
                 2 => 'aardvark'
             ],
-            sort_by($this->list, $this->getProperty, false)
+            sort_by($this->list, function($e) { return strlen($e); }, false)
         );
     }
 
@@ -72,7 +68,7 @@ class SortByTest extends AbstractTestCase
             sort_by(
                 $this->list,
                 function($e, $_) {
-                    return -$this->getProperty($e, $_);
+                    return -strlen($e);
                 },
                 false
             )

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -55,7 +55,7 @@ class SortByTest extends AbstractTestCase
             [
                 0 => 'cat',
                 1 => 'bear',
-                2 => 'aadrvark'
+                2 => 'aardvark'
             ],
             sort_by($this->list, $this->getProperty, false)
         );

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -79,14 +79,15 @@ class SortByTest extends AbstractTestCase
     {
         $this->assertSame(
             [
-                0 => 'aardvark',
-                1 => 'cat',
-                2 => 'bear',
+                0 => 'cat',
+                1 => 'bear',
+                2 => 'aardvark',
             ],
             sort_by(
                 $this->list,
                 function($e, $collection) {
-                    return strlen($collection[(array_search($e, $collection) + 1) % count($collection)]);
+                    $this->assertSame($collection, $this->list);
+                    return strlen($e);
                 },
                 false
             )

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -26,7 +26,7 @@ namespace Functional\Tests;
 use ArrayIterator;
 use function Functional\sort_by;
 
-class SortyByTest extends AbstractTestCase
+class SortByTest extends AbstractTestCase
 {
     public function setUp()
     {

--- a/tests/Functional/SortByTest.php
+++ b/tests/Functional/SortByTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright (C) 2011-2017 by Lars Strojny <lstrojny@php.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Functional\Tests;
+
+use ArrayIterator;
+use function Functional\sort_by;
+
+class SortyByTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->list = ['bear', 'cat', 'aardvark'];
+        $this->listIterator = new ArrayIterator($this->list);
+        $this->hash = ['c' => 'cat', 'b' => 'bear', 'a' => 'aardvark'];
+        $this->hashIterator = new ArrayIterator($this->hash);
+        $this->getProperty =
+            function($e, $_) {
+                return strlen($e);
+            };
+    }
+
+    public function testPreserveKeys()
+    {
+        $this->assertSame(
+            [1 => 'cat', 0 => 'bear', 2 => 'aardvark'],
+            sort_by($this->list, $this->getProperty, true)
+        );
+    }
+
+    public function testWithoutPreserveKeys()
+    {
+        $this->assertSame(
+            [
+                0 => 'cat',
+                1 => 'bear',
+                2 => 'aadrvark'
+            ],
+            sort_by($this->list, $this->getProperty, false)
+        );
+    }
+
+    public function testReverseSort()
+    {
+        $this->assertSame(
+            [
+                0 => 'aardvark',
+                1 => 'bear',
+                2 => 'cat'
+            ],
+            sort_by(
+                $this->list,
+                function($e, $_) {
+                    return -$this->getProperty($e, $_);
+                },
+                false
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
I implemented the function, but tests for it are failing, because for some reason PHPUnit thinks that the sort_by function is not defined. I don't know why that error occurs, as far as I can see the function is defined and used correctly. @lstrojny Can you help me with this one?

Fixes #162 