### PR TITLE
Exception Type Information

### DIFF
--- a/src/Functional/Exceptions/InvalidArgumentException.php
+++ b/src/Functional/Exceptions/InvalidArgumentException.php
@@ -96,7 +96,7 @@ class InvalidArgumentException extends \InvalidArgumentException
                     '%s() expects parameter %d to be string, %s given',
                     $callee,
                     $parameterPosition,
-                    gettype($methodName)
+                    self::getType($methodName)
                 )
             );
         }
@@ -119,7 +119,7 @@ class InvalidArgumentException extends \InvalidArgumentException
                     '%s() expects parameter %d to be a valid property name or array index, %s given',
                     $callee,
                     $parameterPosition,
-                    gettype($propertyName)
+                    self::getType($propertyName)
                 )
             );
         }
@@ -129,7 +129,7 @@ class InvalidArgumentException extends \InvalidArgumentException
     {
         if ((string)(int)$value !== (string)$value || $value < 0) {
 
-            $type = gettype($value);
+            $type = self::getType($value);
             $type = $type === 'integer' ? 'negative integer' : $type;
 
             throw new static(
@@ -191,9 +191,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         if (!is_bool($value)) {
             throw new static(
                 sprintf(
-                    '%s() expects parameter %d to be boolean',
+                    '%s() expects parameter %d to be boolean, %s given',
                     $callee,
-                    $parameterPosition
+                    $parameterPosition,
+                    self::getType($value)
                 )
             );
         }
@@ -210,9 +211,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         if (!is_integer($value)) {
             throw new static(
                 sprintf(
-                    '%s() expects parameter %d to be integer',
+                    '%s() expects parameter %d to be integer, %s given',
                     $callee,
-                    $parameterPosition
+                    $parameterPosition,
+                    self::getType($value)
                 )
             );
         }
@@ -281,12 +283,18 @@ class InvalidArgumentException extends \InvalidArgumentException
         if (!is_array($collection) && !$collection instanceof $className) {
             throw new static(
                 sprintf(
-                    '%s() expects parameter %d to be array or instance of %s',
+                    '%s() expects parameter %d to be array or instance of %s, %s given',
                     $callee,
                     $parameterPosition,
-                    $className
+                    $className,
+                    self::getType($collection)
                 )
             );
         }
+    }
+
+    private static function getType($value)
+    {
+        return is_object($value) ? get_class($value) : gettype($value);
     }
 }

--- a/tests/Functional/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/Functional/Exceptions/InvalidArgumentExceptionTest.php
@@ -69,7 +69,7 @@ class InvalidArgumentExceptionTest extends TestCase
     public function testExceptionIfStringIsPassedAsList()
     {
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
-        $this->expectExceptionMessage("func() expects parameter 4 to be array or instance of Traversable");
+        $this->expectExceptionMessage("func() expects parameter 4 to be array or instance of Traversable, string given");
 
         InvalidArgumentException::assertCollection('string', 'func', 4);
     }
@@ -77,7 +77,7 @@ class InvalidArgumentExceptionTest extends TestCase
     public function testExceptionIfObjectIsPassedAsList()
     {
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
-        $this->expectExceptionMessage("func() expects parameter 2 to be array or instance of Traversable");
+        $this->expectExceptionMessage("func() expects parameter 2 to be array or instance of Traversable, stdClass given");
 
         InvalidArgumentException::assertCollection(new \stdClass(), 'func', 2);
     }
@@ -93,21 +93,21 @@ class InvalidArgumentExceptionTest extends TestCase
     public function testAssertArrayAccessWithString()
     {
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
-        $this->expectExceptionMessage('func() expects parameter 4 to be array or instance of ArrayAccess');
+        $this->expectExceptionMessage('func() expects parameter 4 to be array or instance of ArrayAccess, string given');
         InvalidArgumentException::assertArrayAccess('string', "func", 4);
     }
 
     public function testAssertArrayAccessWithStandardClass()
     {
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
-        $this->expectExceptionMessage('func() expects parameter 2 to be array or instance of ArrayAccess');
+        $this->expectExceptionMessage('func() expects parameter 2 to be array or instance of ArrayAccess, stdClass given');
         InvalidArgumentException::assertArrayAccess(new \stdClass(), "func", 2);
     }
 
     public function testExceptionIfInvalidMethodName()
     {
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
-        $this->expectExceptionMessage('foo() expects parameter 2 to be string, object given');
+        $this->expectExceptionMessage('foo() expects parameter 2 to be string, stdClass given');
         InvalidArgumentException::assertMethodName(new \stdClass(), "foo", 2);
     }
 
@@ -117,7 +117,7 @@ class InvalidArgumentExceptionTest extends TestCase
         InvalidArgumentException::assertPropertyName(0, 'func', 2);
         InvalidArgumentException::assertPropertyName(0.2, 'func', 2);
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
-        $this->expectExceptionMessage('func() expects parameter 2 to be a valid property name or array index, object given');
+        $this->expectExceptionMessage('func() expects parameter 2 to be a valid property name or array index, stdClass given');
         InvalidArgumentException::assertPropertyName(new \stdClass(), "func", 2);
     }
 
@@ -139,5 +139,33 @@ class InvalidArgumentExceptionTest extends TestCase
         $this->expectException('Functional\Exceptions\InvalidArgumentException');
         $this->expectExceptionMessage('func() expects parameter 2 to be positive integer, string given');
         InvalidArgumentException::assertPositiveInteger('str', 'func', 2);
+    }
+
+    public function testAssertIntegerAccessWithString()
+    {
+        $this->expectException('Functional\Exceptions\InvalidArgumentException');
+        $this->expectExceptionMessage('func() expects parameter 4 to be integer, string given');
+        InvalidArgumentException::assertInteger('string', "func", 4);
+    }
+
+    public function testAssertIntegerAccessWithObject()
+    {
+        $this->expectException('Functional\Exceptions\InvalidArgumentException');
+        $this->expectExceptionMessage('func() expects parameter 4 to be integer, stdClass given');
+        InvalidArgumentException::assertInteger(new \stdClass(), "func", 4);
+    }
+
+    public function testAssertBooleanAccessWithString()
+    {
+        $this->expectException('Functional\Exceptions\InvalidArgumentException');
+        $this->expectExceptionMessage('func() expects parameter 4 to be boolean, string given');
+        InvalidArgumentException::assertBoolean('string', "func", 4);
+    }
+
+    public function testAssertBooleanAccessWithObject()
+    {
+        $this->expectException('Functional\Exceptions\InvalidArgumentException');
+        $this->expectExceptionMessage('func() expects parameter 4 to be boolean, stdClass given');
+        InvalidArgumentException::assertBoolean(new \stdClass(), "func", 4);
     }
 }

--- a/tests/Functional/PluckTest.php
+++ b/tests/Functional/PluckTest.php
@@ -224,7 +224,7 @@ class PluckTest extends AbstractTestCase
 
     public function testPassNoPropertyName()
     {
-        $this->expectArgumentError('Functional\pluck() expects parameter 2 to be a valid property name or array index, object given');
+        $this->expectArgumentError('Functional\pluck() expects parameter 2 to be a valid property name or array index, stdClass given');
         pluck($this->propertyExistsSomewhere, new \stdClass());
     }
 


### PR DESCRIPTION
Adds the type of the given (invalid) argument to more exception messages. I see this `%s given` suffix is in use on a few already, I've expanded it to other assertions as well.