### PR TITLE
Then instead of than?

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ collection](http://www.scala-lang.org/archives/downloads/distrib/files/nightly/d
 [Underscore.js](http://underscorejs.org/)
 
   - Works with arrays and everything implementing interface `Traversable`
-  - Consistent interface: for functions taking collections and callbacks, first parameter is always the collection, than the callback.
+  - Consistent interface: for functions taking collections and callbacks, first parameter is always the collection, then the callback.
 Callbacks are always passed `$value`, `$index`, `$collection`. Strict comparison is the default but can be changed
   - Calls 5.3 closures as well as usual callbacks
   - All functions reside in namespace `Functional` to not raise conflicts with any other extension or library


### PR DESCRIPTION
Not a native speaker, but shouldn't it be `then` instead of `than`?