### PR TITLE
Fix return type annotation on identical()

### DIFF
--- a/src/Functional/Identical.php
+++ b/src/Functional/Identical.php
@@ -26,7 +26,7 @@ namespace Functional;
  * Returns true if $a is equal to $b, and they are of the same type.
  *
  * @param mixed $b
- * @return bool
+ * @return callable
  */
 function identical($b)
 {


### PR DESCRIPTION
IDEs returning type mismatches even though code works.