### PR TITLE
Type hints for PHPStorm

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,21 @@
+<?php
+
+// see https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata
+
+namespace PHPSTORM_META;
+
+override(\Functional\but_last(0), type(0));
+override(\Functional\drop_first(0), type(0));
+override(\Functional\drop_last(0), type(0));
+override(\Functional\filter(0), type(0));
+override(\Functional\first(0), elementType(0));
+override(\Functional\head(0), elementType(0));
+override(\Functional\id(0), type(0));
+override(\Functional\last(0), elementType(0));
+override(\Functional\pick(0), elementType(0));
+override(\Functional\reindex(0), type(0));
+override(\Functional\reject(0), type(0));
+override(\Functional\select(0), type(0));
+override(\Functional\sort(0), type(0));
+override(\Functional\tail(0), type(0));
+override(\Functional\unique(0), type(0));


### PR DESCRIPTION
Type hinting in PHPStorm can be improved a bit by providing a special `.phpstorm.meta.php` file.