### PR TITLE
PSR-2 code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build/
-/phpunit.xml
-/vendor
+vendor/
+.php_cs.cache
+phpunit.xml
+phpcs.xml
 composer.lock
-/.idea/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: php
 sudo: false
+
 php:
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - nightly
-
 matrix:
   allow_failures:
     - php: nightly
 
-before_script: composer install
-script: vendor/bin/phpunit --debug
+before_script:
+  - composer install
+script:
+  - composer tests
+  - composer coding-style

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
     },
     "scripts": {
         "tests": "vendor/bin/phpunit",
-        "coding-style": "vendor/bin/phpcs",
+        "coding-style": "vendor/bin/phpcs && vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php_cs.dist",
         "clear": "rm -rf vendor/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php": "~7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6"
+        "phpunit/phpunit": "~6",
+        "squizlabs/php_codesniffer": "~3.0"
     },
     "autoload": {
         "psr-4": {"Functional\\": "src/Functional"},
@@ -113,11 +114,9 @@
     "autoload-dev": {
         "psr-4": {"Functional\\Tests\\": "tests/Functional"}
     },
-    "extra": {
-        "branch-alias": { "dev-master": "1.2-dev" }
-    },
     "scripts": {
-        "tests": "phpunit",
+        "tests": "vendor/bin/phpunit",
+        "coding-style": "vendor/bin/phpcs",
         "clear": "rm -rf vendor/"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="PHP_CodeSniffer"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description>Functional PHP coding style configuration</description>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <arg name="colors"/>
+    <arg value="n"/>
+
+    <rule ref="PSR2" />
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase">
+        <exclude-pattern>src/Functional/Functional.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/src/Functional/Average.php
+++ b/src/Functional/Average.php
@@ -39,12 +39,10 @@ function average($collection)
     $divisor = 0;
 
     foreach ($collection as $element) {
-
         if (is_numeric($element)) {
             $sum += $element;
             ++$divisor;
         }
-
     }
 
     if ($sum === null) {

--- a/src/Functional/ButLast.php
+++ b/src/Functional/ButLast.php
@@ -21,6 +21,7 @@
  * THE SOFTWARE.
  */
 namespace Functional;
+
 use Functional\Exceptions\InvalidArgumentException;
 use Traversable;
 

--- a/src/Functional/CompareObjectHashOn.php
+++ b/src/Functional/CompareObjectHashOn.php
@@ -37,4 +37,3 @@ function compare_object_hash_on(callable $comparison, callable $keyFunction = nu
 
     return compare_on($comparison, $keyFunction);
 }
-

--- a/src/Functional/CompareOn.php
+++ b/src/Functional/CompareOn.php
@@ -21,6 +21,7 @@
  * THE SOFTWARE.
  */
 namespace Functional;
+
 /**
  * Returns a comparison function that can be used with e.g. `usort()`
  *
@@ -40,4 +41,3 @@ function compare_on(callable $comparison, callable $reducer = null)
         return $comparison($reducer($left), $reducer($right));
     };
 }
-

--- a/src/Functional/Contains.php
+++ b/src/Functional/Contains.php
@@ -39,11 +39,9 @@ function contains($collection, $value, $strict = true)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $element) {
-
         if ($value === $element || (!$strict && $value == $element)) {
             return true;
         }
-
     }
 
     return false;

--- a/src/Functional/Curry.php
+++ b/src/Functional/Curry.php
@@ -36,7 +36,7 @@ use Closure;
  */
 function curry(callable $function, $required = true)
 {
-    if (method_exists('Closure','fromCallable')) {
+    if (method_exists('Closure', 'fromCallable')) {
         $reflection = new ReflectionFunction(Closure::fromCallable($function));
     } else {
         if (is_string($function) && strpos($function, '::', 1) !== false) {

--- a/src/Functional/Difference.php
+++ b/src/Functional/Difference.php
@@ -38,11 +38,9 @@ function difference($collection, $initial = 0)
 
     $result = $initial;
     foreach ($collection as $value) {
-
         if (is_numeric($value)) {
             $result -= $value;
         }
-
     }
 
     return $result;

--- a/src/Functional/DropFirst.php
+++ b/src/Functional/DropFirst.php
@@ -40,7 +40,6 @@ function drop_first($collection, callable $callback)
 
     $drop = true;
     foreach ($collection as $index => $element) {
-
         if ($drop) {
             if ($callback($element, $index, $collection)) {
                 continue;

--- a/src/Functional/DropLast.php
+++ b/src/Functional/DropLast.php
@@ -41,7 +41,6 @@ function drop_last($collection, callable $callback)
 
     $drop = false;
     foreach ($collection as $index => $element) {
-
         if (!$drop && !$callback($element, $index, $collection)) {
             break;
         }

--- a/src/Functional/Each.php
+++ b/src/Functional/Each.php
@@ -38,8 +38,6 @@ function each($collection, callable $callback)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $index => $element) {
-
         $callback($element, $index, $collection);
-
     }
 }

--- a/src/Functional/Every.php
+++ b/src/Functional/Every.php
@@ -38,11 +38,9 @@ function every($collection, callable $callback)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $index => $element) {
-
         if (!$callback($element, $index, $collection)) {
             return false;
         }
-
     }
 
     return true;

--- a/src/Functional/Exceptions/InvalidArgumentException.php
+++ b/src/Functional/Exceptions/InvalidArgumentException.php
@@ -33,7 +33,6 @@ class InvalidArgumentException extends \InvalidArgumentException
     public static function assertCallback($callback, $callee, $parameterPosition)
     {
         if (!is_callable($callback)) {
-
             if (!is_array($callback) && !is_string($callback)) {
                 throw new static(
                     sprintf(
@@ -128,7 +127,6 @@ class InvalidArgumentException extends \InvalidArgumentException
     public static function assertPositiveInteger($value, $callee, $parameterPosition)
     {
         if ((string)(int)$value !== (string)$value || $value < 0) {
-
             $type = self::getType($value);
             $type = $type === 'integer' ? 'negative integer' : $type;
 
@@ -169,7 +167,7 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     public static function assertArrayKeyExists($collection, $key, $callee)
     {
-    	if (!isset($collection[$key])) {
+        if (!isset($collection[$key])) {
             throw new static(
                 sprintf(
                     '%s(): unknown key "%s"',
@@ -177,7 +175,7 @@ class InvalidArgumentException extends \InvalidArgumentException
                     $key
                 )
             );
-    	}
+        }
     }
 
     /**

--- a/src/Functional/Exceptions/InvalidArgumentException.php
+++ b/src/Functional/Exceptions/InvalidArgumentException.php
@@ -45,7 +45,6 @@ class InvalidArgumentException extends \InvalidArgumentException
 
             $type = gettype($callback);
             switch ($type) {
-
                 case 'array':
                     $type = 'method';
                     $callback = array_values($callback);

--- a/src/Functional/False.php
+++ b/src/Functional/False.php
@@ -36,11 +36,9 @@ function false($collection)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $value) {
-
         if ($value !== false) {
             return false;
         }
-
     }
 
     return true;

--- a/src/Functional/Falsy.php
+++ b/src/Functional/Falsy.php
@@ -36,11 +36,9 @@ function falsy($collection)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $value) {
-
         if ($value) {
             return false;
         }
-
     }
 
     return true;

--- a/src/Functional/First.php
+++ b/src/Functional/First.php
@@ -39,7 +39,6 @@ function first($collection, callable $callback = null)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $index => $element) {
-
         if ($callback === null) {
             return $element;
         }
@@ -47,7 +46,6 @@ function first($collection, callable $callback = null)
         if ($callback($element, $index, $collection)) {
             return $element;
         }
-
     }
 
     return null;

--- a/src/Functional/FlatMap.php
+++ b/src/Functional/FlatMap.php
@@ -47,15 +47,12 @@ function flat_map($collection, callable $callback)
     $flattened = [];
 
     foreach ($collection as $index => $element) {
-
         $result = $callback($element, $index, $collection);
 
         if (is_array($result) || $result instanceof Traversable) {
-
             foreach ($result as $item) {
                 $flattened[] = $item;
             }
-
         } elseif ($result !== null) {
             $flattened[] = $result;
         }

--- a/src/Functional/Flatten.php
+++ b/src/Functional/Flatten.php
@@ -46,7 +46,6 @@ function flatten($collection)
             foreach ($item as $element) {
                 array_unshift($stack, $element);
             }
-
         } else {
             array_unshift($result, $item);
         }

--- a/src/Functional/Flip.php
+++ b/src/Functional/Flip.php
@@ -27,12 +27,12 @@ namespace Functional;
  *
  * If one argument is provided, it is passed to the function without change.
  *
- * @param callable $function the function you want to flip
+ * @param callable $callback the function you want to flip
  * @return callable a flipped version of the given function
  */
 function flip(callable $callback)
 {
-    return function() use ($callback) {
+    return function () use ($callback) {
         return $callback(...\array_reverse(\func_get_args()));
     };
 }

--- a/src/Functional/Flip.php
+++ b/src/Functional/Flip.php
@@ -32,7 +32,7 @@ namespace Functional;
  */
 function flip(callable $callback)
 {
-    return function() use ($callback) {
+    return function () use ($callback) {
         return $callback(...array_reverse(func_get_args()));
     };
 }

--- a/src/Functional/Invoke.php
+++ b/src/Functional/Invoke.php
@@ -42,7 +42,6 @@ function invoke($collection, $methodName, array $arguments = [])
     $aggregation = [];
 
     foreach ($collection as $index => $element) {
-
         $value = null;
 
         $callback = [$element, $methodName];

--- a/src/Functional/InvokeFirst.php
+++ b/src/Functional/InvokeFirst.php
@@ -40,7 +40,6 @@ function invoke_first($collection, $methodName, array $arguments = [])
     InvalidArgumentException::assertMethodName($methodName, __FUNCTION__, 2);
 
     foreach ($collection as $element) {
-
         $callback = [$element, $methodName];
         if (is_callable($callback)) {
             return $callback(...$arguments);

--- a/src/Functional/InvokeLast.php
+++ b/src/Functional/InvokeLast.php
@@ -42,7 +42,6 @@ function invoke_last($collection, $methodName, array $arguments = [])
     $lastCallback = null;
 
     foreach ($collection as $element) {
-
         $callback = [$element, $methodName];
         if (is_callable($callback)) {
             $lastCallback = $callback;
@@ -50,7 +49,7 @@ function invoke_last($collection, $methodName, array $arguments = [])
     }
 
     if (!$lastCallback) {
-    	return null;
+        return null;
     }
 
     return $lastCallback(...$arguments);

--- a/src/Functional/Last.php
+++ b/src/Functional/Last.php
@@ -21,6 +21,7 @@
  * THE SOFTWARE.
  */
 namespace Functional;
+
 use Functional\Exceptions\InvalidArgumentException;
 use Traversable;
 
@@ -38,11 +39,9 @@ function last($collection, callable $callback = null)
 
     $match = null;
     foreach ($collection as $index => $element) {
-
         if ($callback === null || $callback($element, $index, $collection)) {
             $match = $element;
         }
-
     }
 
     return $match;

--- a/src/Functional/Maximum.php
+++ b/src/Functional/Maximum.php
@@ -38,7 +38,6 @@ function maximum($collection)
     $max = null;
 
     foreach ($collection as $element) {
-
         if (!is_numeric($element)) {
             continue;
         }

--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -51,7 +51,7 @@ function memoize(callable $callback = null, $arguments = [], $key = null)
 
     static $keyGenerator = null;
     if (!$keyGenerator) {
-        $keyGenerator = function($value) use (&$keyGenerator) {
+        $keyGenerator = function ($value) use (&$keyGenerator) {
             $type = gettype($value);
             if ($type === 'array') {
                 $key = join(':', map($value, $keyGenerator));

--- a/src/Functional/Minimum.php
+++ b/src/Functional/Minimum.php
@@ -38,7 +38,6 @@ function minimum($collection)
     $max = null;
 
     foreach ($collection as $index => $element) {
-
         if (!is_numeric($element)) {
             continue;
         }

--- a/src/Functional/None.php
+++ b/src/Functional/None.php
@@ -38,11 +38,9 @@ function none($collection, callable $callback)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $index => $element) {
-
         if ($callback($element, $index, $collection)) {
             return false;
         }
-
     }
 
     return true;

--- a/src/Functional/PartialAny.php
+++ b/src/Functional/PartialAny.php
@@ -68,5 +68,7 @@ function placeholder()
     return …();
 }
 
+// phpcs:disable
 /** Define unicode ellipsis constant */
 define('Functional\\…', …());
+// phpcs:enable

--- a/src/Functional/Pluck.php
+++ b/src/Functional/Pluck.php
@@ -41,7 +41,6 @@ function pluck($collection, $propertyName)
     $aggregation = [];
 
     foreach ($collection as $index => $element) {
-
         $value = null;
 
         if (is_object($element) && isset($element->{$propertyName})) {

--- a/src/Functional/Product.php
+++ b/src/Functional/Product.php
@@ -38,11 +38,9 @@ function product($collection, $initial = 1)
 
     $result = $initial;
     foreach ($collection as $value) {
-
         if (is_numeric($value)) {
             $result *= $value;
         }
-
     }
 
     return $result;

--- a/src/Functional/Ratio.php
+++ b/src/Functional/Ratio.php
@@ -38,11 +38,9 @@ function ratio($collection, $initial = 1)
 
     $result = $initial;
     foreach ($collection as $value) {
-
         if (is_numeric($value)) {
             $result /= $value;
         }
-
     }
 
     return $result;

--- a/src/Functional/ReduceLeft.php
+++ b/src/Functional/ReduceLeft.php
@@ -36,9 +36,7 @@ function reduce_left($collection, callable $callback, $initial = null)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $index => $value) {
-
         $initial = $callback($value, $index, $collection, $initial);
-
     }
 
     return $initial;

--- a/src/Functional/ReduceRight.php
+++ b/src/Functional/ReduceRight.php
@@ -37,15 +37,11 @@ function reduce_right($collection, callable $callback, $initial = null)
 
     $data = [];
     foreach ($collection as $index => $value) {
-
         $data[] = [$index, $value];
-
     }
 
     while ((list($index, $value) = array_pop($data))) {
-
         $initial = $callback($value, $index, $collection, $initial);
-
     }
 
     return $initial;

--- a/src/Functional/Reject.php
+++ b/src/Functional/Reject.php
@@ -40,11 +40,9 @@ function reject($collection, callable $callback)
     $aggregation = [];
 
     foreach ($collection as $index => $element) {
-
         if (!$callback($element, $index, $collection)) {
             $aggregation[$index] = $element;
         }
-
     }
 
     return $aggregation;

--- a/src/Functional/Retry.php
+++ b/src/Functional/Retry.php
@@ -56,15 +56,11 @@ function retry(callable $callback, $retries, Traversable $delaySequence = null)
     $retry = 0;
     foreach ($delays as $delay) {
         try {
-
             return $callback($retry, $delay);
-
         } catch (Exception $e) {
-
             if ($retry === $retries - 1) {
                 throw $e;
             }
-
         }
 
         if ($delay > 0) {

--- a/src/Functional/Select.php
+++ b/src/Functional/Select.php
@@ -40,11 +40,9 @@ function select($collection, callable $callback)
     $aggregation = [];
 
     foreach ($collection as $index => $element) {
-
         if ($callback($element, $index, $collection)) {
             $aggregation[$index] = $element;
         }
-
     }
 
     return $aggregation;

--- a/src/Functional/Some.php
+++ b/src/Functional/Some.php
@@ -38,11 +38,9 @@ function some($collection, callable $callback)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $index => $element) {
-
         if ($callback($element, $index, $collection)) {
             return true;
         }
-
     }
 
     return false;

--- a/src/Functional/Sum.php
+++ b/src/Functional/Sum.php
@@ -38,11 +38,9 @@ function sum($collection, $initial = 0)
 
     $result = $initial;
     foreach ($collection as $value) {
-
         if (is_numeric($value)) {
             $result += $value;
         }
-
     }
 
     return $result;

--- a/src/Functional/Tap.php
+++ b/src/Functional/Tap.php
@@ -29,7 +29,8 @@ namespace Functional;
  * @param  callable $callback
  * @return mixed
  */
-function tap($value, callable $callback) {
+function tap($value, callable $callback)
+{
     $callback($value);
 
     return $value;

--- a/src/Functional/True.php
+++ b/src/Functional/True.php
@@ -36,11 +36,9 @@ function true($collection)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $value) {
-
         if ($value !== true) {
             return false;
         }
-
     }
 
     return true;

--- a/src/Functional/Truthy.php
+++ b/src/Functional/Truthy.php
@@ -36,11 +36,9 @@ function truthy($collection)
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     foreach ($collection as $value) {
-
         if (!$value) {
             return false;
         }
-
     }
 
     return true;

--- a/src/Functional/Unique.php
+++ b/src/Functional/Unique.php
@@ -40,7 +40,6 @@ function unique($collection, callable $callback = null, $strict = true)
     $indexes = [];
     $aggregation = [];
     foreach ($collection as $key => $element) {
-
         if ($callback) {
             $index = $callback($element, $key, $collection);
         } else {

--- a/tests/Functional/ComposeTest.php
+++ b/tests/Functional/ComposeTest.php
@@ -35,9 +35,15 @@ class ComposeTest extends AbstractTestCase
     {
         $input = range(0, 10);
 
-        $plus2 = function ($x) { return $x + 2; };
-        $times4 = function ($x) { return $x * 4; };
-        $square = function ($x) { return $x * $x; };
+        $plus2 = function ($x) {
+            return $x + 2;
+        };
+        $times4 = function ($x) {
+            return $x * 4;
+        };
+        $square = function ($x) {
+            return $x * $x;
+        };
 
         $composed = compose($plus2, $times4, $square);
 

--- a/tests/Functional/CurryNTest.php
+++ b/tests/Functional/CurryNTest.php
@@ -27,7 +27,8 @@ use function Functional\invoker;
 
 use DateTime;
 
-function add($a, $b, $c, $d) {
+function add($a, $b, $c, $d)
+{
     return $a + $b + $c + $d;
 }
 
@@ -70,7 +71,7 @@ class CurryNTest extends AbstractPartialTestCase
         $this->assertEquals($transformer($expected), $transformer(call_user_func_array($curryied, $params)));
 
         $length = count($params);
-        for($i = 0; $i < $length; ++$i) {
+        for ($i = 0; $i < $length; ++$i) {
             $p = array_shift($params);
 
             $curryied = $curryied($p);

--- a/tests/Functional/CurryNTest.php
+++ b/tests/Functional/CurryNTest.php
@@ -34,19 +34,19 @@ function add($a, $b, $c, $d)
 
 class Adder
 {
-    public static function static_add($a, $b, $c, $d)
+    public static function staticAdd($a, $b, $c, $d)
     {
         return add($a, $b, $c, $d);
     }
 
     public function add($a, $b, $c, $d)
     {
-        return static::static_add($a, $b, $c, $d);
+        return static::staticAdd($a, $b, $c, $d);
     }
 
     public function __invoke($a, $b, $c, $d)
     {
-        return static::static_add($a, $b, $c, $d);
+        return static::staticAdd($a, $b, $c, $d);
     }
 }
 
@@ -94,11 +94,11 @@ class CurryNTest extends AbstractPartialTestCase
 
         return [
             ['Functional\Tests\add', [2, 4, 6, 8], 20, true],
-            [['Functional\Tests\Adder', 'static_add'], [2, 4, 6, 8], 20, true],
-            ['Functional\Tests\Adder::static_add', [2, 4, 6, 8], 20, true],
+            [['Functional\Tests\Adder', 'staticAdd'], [2, 4, 6, 8], 20, true],
+            ['Functional\Tests\Adder::staticAdd', [2, 4, 6, 8], 20, true],
             [new Adder(), [2, 4, 6, 8], 20, true],
             [[new Adder(), 'add'], [2, 4, 6, 8], 20, true],
-            [[new Adder(), 'static_add'], [2, 4, 6, 8], 20, true],
+            [[new Adder(), 'staticAdd'], [2, 4, 6, 8], 20, true],
 
             ['number_format', [1.234, 2, ',', '\''], '1,23', false],
             [['DateTime', 'createFromFormat'], [DateTime::ATOM, $dt->format(DateTime::ATOM)], $dt, true, $dateFormat],

--- a/tests/Functional/DropTest.php
+++ b/tests/Functional/DropTest.php
@@ -40,7 +40,7 @@ class DropTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             $return = is_int($k) ? ($k != 2) : ($v[3] != 3);
             return $return;

--- a/tests/Functional/ErrorToExceptionTest.php
+++ b/tests/Functional/ErrorToExceptionTest.php
@@ -63,7 +63,7 @@ class ErrorToExceptionTest extends AbstractTestCase
     {
         $errorMessage = null;
         set_error_handler(
-            static function($level, $message) use (&$errorMessage) {
+            static function ($level, $message) use (&$errorMessage) {
                 $errorMessage = $message;
             }
         );

--- a/tests/Functional/FirstIndexOfTest.php
+++ b/tests/Functional/FirstIndexOfTest.php
@@ -56,7 +56,9 @@ class FirstIndexOfTest extends AbstractTestCase
     {
         $this->assertSame(
             0,
-            first_index_of($this->list, function($element) {return $element;})
+            first_index_of($this->list, function ($element) {
+                return $element;
+            })
         );
     }
 

--- a/tests/Functional/FirstTest.php
+++ b/tests/Functional/FirstTest.php
@@ -51,7 +51,7 @@ class FirstTest extends AbstractTestCase
      */
     public function test($functionName)
     {
-        $callback = function($v, $k, $collection) {
+        $callback = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
             return $v == 'second' && $k == 1;
         };

--- a/tests/Functional/FlatMapTest.php
+++ b/tests/Functional/FlatMapTest.php
@@ -42,7 +42,7 @@ class FlatMapTest extends AbstractTestCase
     {
         $flat = flat_map(
             ['a', ['b'], ['C'=>'c'], [['d']], null],
-            function($v, $k, $collection) {
+            function ($v, $k, $collection) {
                 InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
                 return $v;
             }
@@ -55,7 +55,7 @@ class FlatMapTest extends AbstractTestCase
     {
         $flat = flat_map(
             new ArrayIterator(['a', ['b'], ['C'=>'c'], [['d']], null]),
-            function($v, $k, $collection) {
+            function ($v, $k, $collection) {
                 InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
                 return $v;
             }
@@ -68,7 +68,7 @@ class FlatMapTest extends AbstractTestCase
     {
         $flat = flat_map(
             ['ka' => 'a', 'kb' => ['b'], 'kc' => ['C'=>'c'], 'kd' => [['d']], 'ke' => null, null],
-            function($v, $k, $collection) {
+            function ($v, $k, $collection) {
                 InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
                 return $v;
             }
@@ -81,7 +81,7 @@ class FlatMapTest extends AbstractTestCase
     {
         $flat = flat_map(
             new ArrayIterator(['ka' => 'a', 'kb' => ['b'], 'kc' => ['C'=>'c'], 'kd' => [['d']], 'ke' => null, null]),
-            function($v, $k, $collection) {
+            function ($v, $k, $collection) {
                 InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
                 return $v;
             }

--- a/tests/Functional/FlipTest.php
+++ b/tests/Functional/FlipTest.php
@@ -44,7 +44,7 @@ class FlipTest extends AbstractTestCase
     public function testFlippedFilter()
     {
         $data = [1, 2, 3, 4];
-        $getEven = function($number) {
+        $getEven = function ($number) {
             return $number % 2 == 0;
         };
         $flippedFilter = flip('Functional\filter');

--- a/tests/Functional/GroupTest.php
+++ b/tests/Functional/GroupTest.php
@@ -39,7 +39,7 @@ class GroupTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return (is_int($k) ? ($k % 2 == 0) : ($v[3] % 2 == 0)) ? 'foo' : '';
         };
@@ -53,7 +53,7 @@ class GroupTest extends AbstractTestCase
     {
         $array = ['v1', 'v2', 'v3', 'v4', 'v5', 'v6'];
         $keyMap = [true, 1, -1, 2.1, 'str', null];
-        $fn = function($v, $k, $collection) use(&$keyMap) {
+        $fn = function ($v, $k, $collection) use (&$keyMap) {
             return $keyMap[$k];
         };
         $result = [

--- a/tests/Functional/IntersperseTest.php
+++ b/tests/Functional/IntersperseTest.php
@@ -53,7 +53,8 @@ class IntersperseTest extends AbstractTestCase
     {
         $this->expectArgumentError(
             'Functional\intersperse() expects parameter 1 to be array or '.
-            'instance of Traversable');
+            'instance of Traversable'
+        );
         intersperse('invalidCollection', '-');
     }
 }

--- a/tests/Functional/InvokeFirstTest.php
+++ b/tests/Functional/InvokeFirstTest.php
@@ -52,8 +52,8 @@ class InvokeFirstTest extends AbstractTestCase
 
     public function testSkipNonCallables()
     {
-    	$this->assertSame('methodValue', invoke_first($this->arrayVeryFirstNotCallable, 'method', [1, 2]));
-    	$this->assertSame('methodValue', invoke_first($this->iteratorVeryFirstNotCallable, 'method'));
+        $this->assertSame('methodValue', invoke_first($this->arrayVeryFirstNotCallable, 'method', [1, 2]));
+        $this->assertSame('methodValue', invoke_first($this->iteratorVeryFirstNotCallable, 'method'));
         $this->assertSame(null, invoke_first($this->arrayVeryFirstNotCallable, 'undefinedMethod'));
         $this->assertSame(null, invoke_first($this->arrayVeryFirstNotCallable, 'setExpectedExceptionFromAnnotation'), 'Protected method');
         $this->assertSame([1, 2], invoke_first($this->arrayVeryFirstNotCallable, 'returnArguments', [1, 2]));

--- a/tests/Functional/InvokeLastTest.php
+++ b/tests/Functional/InvokeLastTest.php
@@ -52,8 +52,8 @@ class InvokeLastTest extends AbstractTestCase
 
     public function testSkipNonCallables()
     {
-    	$this->assertSame('methodValue', invoke_last($this->arrayVeryLastNotCallable, 'method', [1, 2]));
-    	$this->assertSame('methodValue', invoke_last($this->iteratorVeryLastNotCallable, 'method'));
+        $this->assertSame('methodValue', invoke_last($this->arrayVeryLastNotCallable, 'method', [1, 2]));
+        $this->assertSame('methodValue', invoke_last($this->iteratorVeryLastNotCallable, 'method'));
     }
 
     public function testPassNoCollection()

--- a/tests/Functional/LastIndexOfTest.php
+++ b/tests/Functional/LastIndexOfTest.php
@@ -56,7 +56,9 @@ class LastIndexOfTest extends AbstractTestCase
     {
         $this->assertSame(
             3,
-            last_index_of($this->list, function($element) {return $element;})
+            last_index_of($this->list, function ($element) {
+                return $element;
+            })
         );
     }
 

--- a/tests/Functional/LastTest.php
+++ b/tests/Functional/LastTest.php
@@ -39,7 +39,7 @@ class LastTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
             return ($v == 'first' && $k == 0) || ($v == 'third' && $k == 2);
         };

--- a/tests/Functional/MapTest.php
+++ b/tests/Functional/MapTest.php
@@ -39,7 +39,7 @@ class MapTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return $k . $v;
         };

--- a/tests/Functional/MatchTest.php
+++ b/tests/Functional/MatchTest.php
@@ -34,7 +34,9 @@ class MatchTest extends AbstractTestCase
             [equal('foo'), const_function('is foo')],
             [equal('bar'), const_function('is bar')],
             [equal('baz'), const_function('is baz')],
-            [const_function(true), function ($x) { return 'default is '.$x; }],
+            [const_function(true), function ($x) {
+                return 'default is '.$x;
+            }],
         ]);
 
         $this->assertEquals('is foo', $test('foo'));
@@ -57,7 +59,8 @@ class MatchTest extends AbstractTestCase
     {
         $this->expectArgumentError('Functional\match() expects condition at key 1 to be array, string given');
 
-        $callable = function () {};
+        $callable = function () {
+        };
 
         $test = match([
             [$callable, $callable],
@@ -69,7 +72,8 @@ class MatchTest extends AbstractTestCase
     {
         $this->expectArgumentError('Functional\match() expects size of condition at key 1 to be greater than or equals to 2, 1 given');
 
-        $callable = function () {};
+        $callable = function () {
+        };
 
         $test = match([
             [$callable, $callable],
@@ -82,7 +86,8 @@ class MatchTest extends AbstractTestCase
         $this->expectException(\Functional\Exceptions\InvalidArgumentException::class);
         $this->expectExceptionMessage('Functional\match() expects first two items of condition at key 1 to be callables');
 
-        $callable = function () {};
+        $callable = function () {
+        };
 
         $test = match([
             [$callable, $callable],

--- a/tests/Functional/MemoizeTest.php
+++ b/tests/Functional/MemoizeTest.php
@@ -90,7 +90,7 @@ class MemoizeTest extends AbstractTestCase
 
     public function testMemoizeClosureCall()
     {
-        $closure = function() {
+        $closure = function () {
             return 'CLOSURE VALUE' . MemoizeTest::invoke('Closure');
         };
         $this->assertSame('CLOSURE VALUE1', memoize($closure));

--- a/tests/Functional/PartialAnyTest.php
+++ b/tests/Functional/PartialAnyTest.php
@@ -16,7 +16,7 @@ class PartialAnyTest extends AbstractPartialTestCase
         $this->assertSame(2, $ratio(20));
     }
 
-    public function testBindWithPlaceholder_Constant()
+    public function testBindWithPlaceholderConstant()
     {
         $context = hash_init('md2');
         $hash = partial_any('hash_update', $context, …());

--- a/tests/Functional/PartitionTest.php
+++ b/tests/Functional/PartitionTest.php
@@ -39,7 +39,7 @@ class PartitionTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return is_int($k) ? ($k % 2 == 0) : ($v[3] % 2 == 0);
         };
@@ -51,12 +51,12 @@ class PartitionTest extends AbstractTestCase
 
     public function testMultiFn()
     {
-        $fn1 = function($v, $k, $collection) {
+        $fn1 = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return is_int($k) ? ($k === 1) : ($v[3] === '2');
         };
 
-        $fn2 = function($v, $k, $collection) {
+        $fn2 = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return is_int($k) ? ($k === 2) : ($v[3] === '3');
         };

--- a/tests/Functional/PluckTest.php
+++ b/tests/Functional/PluckTest.php
@@ -145,7 +145,6 @@ class PluckTest extends AbstractTestCase
 
     public function variate($array, $asObject)
     {
-
         if (!$asObject) {
             return [
                 [$array],

--- a/tests/Functional/PollTest.php
+++ b/tests/Functional/PollTest.php
@@ -76,7 +76,7 @@ class PollTest extends AbstractTestCase
             ->method('poll')
             ->with(0, 0)
             ->willReturnCallback(
-                function() {
+                function () {
                     usleep(100);
                     return false;
                 }

--- a/tests/Functional/ReduceTest.php
+++ b/tests/Functional/ReduceTest.php
@@ -49,19 +49,31 @@ class ReduceTest extends AbstractTestCase
         $this->assertSame('2:three,1:two,0:one', reduce_right($this->listIterator, [$this, 'functionalCallback']));
         $this->assertSame('default,2:three,1:two,0:one', reduce_right($this->listIterator, [$this, 'functionalCallback'], 'default'));
 
-        $this->assertSame('initial', reduce_left([], function(){}, 'initial'));
-        $this->assertNull(reduce_left([], function(){}));
-        $this->assertNull(reduce_left([], function(){}, null));
-        $this->assertSame('initial', reduce_left(new ArrayIterator([]), function(){}, 'initial'));
-        $this->assertNull(reduce_left(new ArrayIterator([]), function(){}));
-        $this->assertNull(reduce_left(new ArrayIterator([]), function(){}, null));
-        $this->assertSame('initial', reduce_right([], function(){}, 'initial'));
-        $this->assertNull(reduce_right([], function(){}));
-        $this->assertNull(reduce_right([], function(){}, null));
-        $this->assertSame('initial', reduce_right(new ArrayIterator([]), function(){}, 'initial'));
-        $this->assertNull(reduce_right(new ArrayIterator([]), function(){}));
-        $this->assertNull(reduce_right(new ArrayIterator([]), function(){}, null));
-   }
+        $this->assertSame('initial', reduce_left([], function () {
+        }, 'initial'));
+        $this->assertNull(reduce_left([], function () {
+        }));
+        $this->assertNull(reduce_left([], function () {
+        }, null));
+        $this->assertSame('initial', reduce_left(new ArrayIterator([]), function () {
+        }, 'initial'));
+        $this->assertNull(reduce_left(new ArrayIterator([]), function () {
+        }));
+        $this->assertNull(reduce_left(new ArrayIterator([]), function () {
+        }, null));
+        $this->assertSame('initial', reduce_right([], function () {
+        }, 'initial'));
+        $this->assertNull(reduce_right([], function () {
+        }));
+        $this->assertNull(reduce_right([], function () {
+        }, null));
+        $this->assertSame('initial', reduce_right(new ArrayIterator([]), function () {
+        }, 'initial'));
+        $this->assertNull(reduce_right(new ArrayIterator([]), function () {
+        }));
+        $this->assertNull(reduce_right(new ArrayIterator([]), function () {
+        }, null));
+    }
 
     public function testExceptionThrownInIteratorCallbackWhileReduceLeft()
     {

--- a/tests/Functional/ReindexTest.php
+++ b/tests/Functional/ReindexTest.php
@@ -39,7 +39,7 @@ class ReindexTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return $k . $v;
         };

--- a/tests/Functional/RejectTest.php
+++ b/tests/Functional/RejectTest.php
@@ -39,7 +39,7 @@ class RejectTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return $v == 'wrong' && strlen($k) > 0;
         };

--- a/tests/Functional/SelectTest.php
+++ b/tests/Functional/SelectTest.php
@@ -51,7 +51,7 @@ class SelectTest extends AbstractTestCase
      */
     public function test($functionName)
     {
-        $callback = function($v, $k, $collection) {
+        $callback = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return $v == 'value' && strlen($k) > 0;
         };

--- a/tests/Functional/SelectTest.php
+++ b/tests/Functional/SelectTest.php
@@ -71,7 +71,7 @@ class SelectTest extends AbstractTestCase
                 "Argument 2 passed to %s() must be callable",
                 $functionName
             )
-         );
+        );
         $functionName($this->list, 'undefinedFunction');
     }
 

--- a/tests/Functional/SortTest.php
+++ b/tests/Functional/SortTest.php
@@ -36,7 +36,7 @@ class SortTest extends AbstractTestCase
         $this->listIterator = new ArrayIterator($this->list);
         $this->hash = ['c' => 'cat', 'b' => 'bear', 'a' => 'aardvark'];
         $this->hashIterator = new ArrayIterator($this->hash);
-        $this->sortCallback = function($left, $right, $collection) {
+        $this->sortCallback = function ($left, $right, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 3);
             return strcmp($left, $right);
         };

--- a/tests/Functional/SuppressErrorTest.php
+++ b/tests/Functional/SuppressErrorTest.php
@@ -59,7 +59,7 @@ class SuppressErrorTest extends AbstractTestCase
     {
         $errorMessage = null;
         set_error_handler(
-            static function($level, $message) use (&$errorMessage) {
+            static function ($level, $message) use (&$errorMessage) {
                 $errorMessage = $message;
             }
         );

--- a/tests/Functional/TailTest.php
+++ b/tests/Functional/TailTest.php
@@ -39,7 +39,7 @@ class TailTest extends AbstractTestCase
 
     public function test()
     {
-        $fn = function($v, $k, $collection) {
+        $fn = function ($v, $k, $collection) {
             InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
             return $v > 2;
         };

--- a/tests/Functional/UniqueTest.php
+++ b/tests/Functional/UniqueTest.php
@@ -44,7 +44,7 @@ class UniqueTest extends AbstractTestCase
         $this->assertSame([0 => 'value1', 1 => 'value2', 3 => 'value'], unique($this->listIterator));
         $this->assertSame(['k1' => 'val1', 'k2' => 'val2'], unique($this->hash));
         $this->assertSame(['k1' => 'val1', 'k2' => 'val2'], unique($this->hashIterator));
-        $fn = function($value, $key, $collection) {
+        $fn = function ($value, $key, $collection) {
             return $value;
         };
         $this->assertSame([0 => 'value1', 1 => 'value2', 3 => 'value'], unique($this->list, $fn));
@@ -55,12 +55,12 @@ class UniqueTest extends AbstractTestCase
 
     public function testUnifyingByClosure()
     {
-        $fn = function($value, $key, $collection) {
+        $fn = function ($value, $key, $collection) {
             return $key === 0 ? 'zero' : 'else';
         };
         $this->assertSame([0 => 'value1', 1 => 'value2'], unique($this->list, $fn));
         $this->assertSame([0 => 'value1', 1 => 'value2'], unique($this->listIterator, $fn));
-        $fn = function($value, $key, $collection) {
+        $fn = function ($value, $key, $collection) {
             return 0;
         };
         $this->assertSame(['k1' => 'val1'], unique($this->hash, $fn));
@@ -74,7 +74,7 @@ class UniqueTest extends AbstractTestCase
         $this->assertSame([0 => 1, 2 => '2', 4 => '3', 5 => 4], unique($this->mixedTypesIterator, null, false));
         $this->assertSame([1, '1', '2', 2, '3', 4], unique($this->mixedTypesIterator));
 
-        $fn = function($value, $key, $collection) {
+        $fn = function ($value, $key, $collection) {
             return $value;
         };
 

--- a/tests/Functional/WithTest.php
+++ b/tests/Functional/WithTest.php
@@ -30,7 +30,7 @@ class WithTest extends AbstractTestCase
     public function testWithNull()
     {
         $this->assertNull(
-            with(null, function() {
+            with(null, function () {
                 throw new \Exception('Should not be called');
             })
         );
@@ -56,7 +56,7 @@ class WithTest extends AbstractTestCase
         $this->assertSame(
             'value',
             with(
-                function() {
+                function () {
                     return 'value';
                 },
                 function ($value) {

--- a/tests/Functional/ZipAllTest.php
+++ b/tests/Functional/ZipAllTest.php
@@ -32,7 +32,7 @@ class ZipAllTest extends AbstractTestCase
         $this->assertSame([], zip_all());
         $this->assertSame([], zip_all([]));
         $this->assertSame([], zip_all([], [], []));
-        $this->assertSame([], zip_all([], [], function() {
+        $this->assertSame([], zip_all([], [], function () {
             throw new BadFunctionCallException('Should not be called');
         }));
     }

--- a/tests/Functional/ZipTest.php
+++ b/tests/Functional/ZipTest.php
@@ -90,7 +90,7 @@ class ZipTest extends AbstractTestCase
                 [1, 2, 3],
                 [-1, -2, -3],
                 [true, false],
-                function($one, $two, $three, $four) {
+                function ($one, $two, $three, $four) {
                     return $one . $two . $three . $four;
                 }
             )
@@ -102,7 +102,7 @@ class ZipTest extends AbstractTestCase
                 new ArrayIterator([1, 2, 3]),
                 new ArrayIterator([-1, -2, -3]),
                 new ArrayIterator([true, false]),
-                function($one, $two, $three, $four) {
+                function ($one, $two, $three, $four) {
                     return $one . $two . $three . $four;
                 }
             )
@@ -133,7 +133,7 @@ class ZipTest extends AbstractTestCase
     {
         $this->assertSame([], zip([]));
         $this->assertSame([], zip([], []));
-        $this->assertSame([], zip([], [], function() {
+        $this->assertSame([], zip([], [], function () {
             throw new BadFunctionCallException('Should not be called');
         }));
     }


### PR DESCRIPTION
PSR-2 has been adopted by most of PHP libraries in the past years, so I think it's a good idea to change the formatting according to this standard.

There are not a lot of changes, though, but I think it's important to apply them, because it allows an arbitrary developer to read code faster and not stumble on the things with different (from most of other library) formatting.

All the changes in the PR come from PHP-CS-Fixer tool with a default config (that follows PSR-2).