### PR TITLE
[issue][memoize] expect different result when using different callable

### DIFF
--- a/tests/Functional/MemoizeTest.php
+++ b/tests/Functional/MemoizeTest.php
@@ -202,11 +202,13 @@ class MemoizeTest extends AbstractTestCase
         };
 
         $callbackHey = function(string $name): string {
-            return 'Hello ' . $name;
+            return 'Hey ' . $name;
         };
 
         $this->assertEquals('Hello john', memoize($callbackHello, ['john']));
         $this->assertEquals('Hey john', memoize($callbackHey, ['john']));
+        $this->assertEquals('Hello joe', memoize($callbackHello, ['joe']));
+        $this->assertEquals('Hey joe', memoize($callbackHey, ['joe']));
     }
 
     public function testPassNoCallable()

--- a/tests/Functional/MemoizeTest.php
+++ b/tests/Functional/MemoizeTest.php
@@ -195,6 +195,20 @@ class MemoizeTest extends AbstractTestCase
         memoize([$this->callback, 'execute']);
     }
 
+    public function testUsingDifferentCallbackWithSameArgument()
+    {
+        $callbackHello = function(string $name): string {
+            return 'Hello ' . $name;
+        };
+
+        $callbackHey = function(string $name): string {
+            return 'Hello ' . $name;
+        };
+
+        $this->assertEquals('Hello john', memoize($callbackHello, ['john']));
+        $this->assertEquals('Hey john', memoize($callbackHey, ['john']));
+    }
+
     public function testPassNoCallable()
     {
         $this->expectArgumentError('Argument 1 passed to Functional\memoize() must be callable');


### PR DESCRIPTION
Hi there.

Look at this explicit test case.
Could not use `memoize` function with callable and auto-generated key. Same thing with Closure.

Regards;
Thomas.