### PR TITLE
added chunk_every function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
             "src/Functional/Average.php",
             "src/Functional/ButLast.php",
             "src/Functional/Capture.php",
+            "src/Functional/ChunkEvery.php",
             "src/Functional/ConstFunction.php",
             "src/Functional/CompareOn.php",
             "src/Functional/CompareObjectHashOn.php",

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -53,6 +53,7 @@
   - [flatten()](#flatten)
   - [reduce_left() & reduce_right()](#reduce_left--reduce_right)
   - [intersperse()](#intersperse)
+  - [chunk_every()](#chunk_every)
   - [Other](#other-1)
 - [Conditional functions](#conditional-functions)
   - [if_else()](#if_else)
@@ -906,6 +907,15 @@ Insert a given value between each element of a collection.
 
 ```php
 intersperse(['a', 'b', 'c'], '-') === ['a', '-', 'b', '-', 'c']
+```
+
+
+## chunk_every()
+
+Chunks a collection by given size, step, and optionally discards the last incomplete chunk.
+
+```php
+chunk_every([1, 2, 3], 2) === [[1, 2], [2, 3], [3]]
 ```
 
 ## Other

--- a/src/Functional/ChunkEvery.php
+++ b/src/Functional/ChunkEvery.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright (C) 2019 by Bas Bloembergen <basbloembergen@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional;
+
+use Functional\Exceptions\InvalidArgumentException;
+use Traversable;
+
+/**
+ * @param Traversable|array $collection
+ * @param int $size Desired size of the chunk
+ * @param int $step Step with which to increment start of next chunk
+ * @param bool $discardIncompleteChunk Discard the last chunk if it does not have the specified size.
+ * @return array
+ */
+function chunk_every($collection, $size = 1, $step = 1, $discardIncompleteChunk = false)
+{
+    InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
+
+    if ($collection instanceof Traversable) {
+        $array = \iterator_to_array($collection);
+    } else {
+        $array = $collection;
+    }
+
+    $return = [];
+    $previousChunk = [];
+    for ($offset = 0, $max = \count($array); $offset <= $max; $offset += $step) {
+        $currentChunk = \array_slice($array, $offset, $size);
+
+        $wasPreviousChunkComplete = \count($previousChunk) === $size;
+        $isCurrentChunkComplete = \count($currentChunk) === $size;
+
+        if (($previousChunk === [] || $wasPreviousChunkComplete)
+            && ($discardIncompleteChunk === false || $isCurrentChunkComplete)
+            && !empty($currentChunk)
+        ) {
+            $return[] = $currentChunk;
+        }
+
+        $previousChunk = $currentChunk;
+    }
+
+    return $return;
+}

--- a/src/Functional/Functional.php
+++ b/src/Functional/Functional.php
@@ -20,6 +20,11 @@ final class Functional
     const capture = '\Functional\capture';
 
     /**
+     * @see \Functional\chunk_every
+     */
+    const chunk_every = '\Functional\chunk_every';
+
+    /**
      * @see \Functional\compare_object_hash_on
      */
     const compare_object_hash_on = '\Functional\compare_object_hash_on';

--- a/tests/Functional/ChunkEveryTest.php
+++ b/tests/Functional/ChunkEveryTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright (C) 2019 by Bas Bloembergen <basbloembergen@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Functional\Tests;
+
+use function Functional\chunk_every;
+
+class ChunkEveryTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function testChunking(array $expected, array $input, int $size, int $step, bool $discardIncompleteChunk)
+    {
+        $this->assertSame(
+            $expected,
+            chunk_every($input, $size, $step, $discardIncompleteChunk)
+        );
+    }
+
+    public static function getData()
+    {
+        return [
+            'single_size_single_step_discard_last_chunk' => [
+                [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]],
+                range(1, 10),
+                1,
+                1,
+                true
+            ],
+            'single_size_single_step_keep_last_chunk' => [
+                [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]],
+                range(1, 10),
+                1,
+                1,
+                false
+            ],
+            'single_size_two_step_discard_last_chunk' => [
+                [[1], [3], [5], [7], [9]],
+                range(1, 10),
+                1,
+                2,
+                true
+            ],
+            'single_size_two_step_keep_last_chunk' => [
+                [[1], [3], [5], [7], [9]],
+                range(1, 10),
+                1,
+                2,
+                false
+            ],
+            'double_size_one_step_discard_last_chunk' => [
+                [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]],
+                range(1, 10),
+                2,
+                1,
+                true
+            ],
+            'double_size_one_step_keep_last_chunk' => [
+                [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10], [10]],
+                range(1, 10),
+                2,
+                1,
+                false
+            ],
+            'double_size_two_step_discard_last_chunk' => [
+                [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]],
+                range(1, 10),
+                2,
+                2,
+                false
+            ],
+            'incomplete_first_chunk_discard_last' => [
+                [],
+                range(1, 10),
+                11,
+                1,
+                true
+            ],
+            'incomplete_first_chunk_keep_last' => [
+                [range(1, 10)],
+                range(1, 10),
+                11,
+                1,
+                false
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## chunk_every

By passing a `$size`, `$step` and whether to `$discardIncompleteChunk` you have full control over the chunks created.

```php
chunk_every([1, 2, 3], 2); // [[1, 2], [2, 3], [3]]
chunk_every([1, 2, 3], 2, 1, true); // [[1, 2], [2, 3]]
```

Inspired by [Elixir](https://hexdocs.pm/elixir/Enum.html#chunk_every/4)