### PR TITLE
Use correct variable name in Minimum

### DIFF
--- a/src/Functional/Minimum.php
+++ b/src/Functional/Minimum.php
@@ -35,17 +35,17 @@ function minimum($collection)
 {
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
-    $max = null;
+    $min = null;
 
     foreach ($collection as $index => $element) {
         if (!\is_numeric($element)) {
             continue;
         }
 
-        if ($element < $max || $max === null) {
-            $max = $element;
+        if ($element < $min || $min === null) {
+            $min = $element;
         }
     }
 
-    return $max;
+    return $min;
 }


### PR DESCRIPTION
It was using `$max` which doesn't make sense in this scope.