### PR TITLE
Add default value for with()

### DIFF
--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -499,7 +499,9 @@ Functional PHP comes with a set of invocation helpers that ease calling function
 
 
 ## with()
-Invoke a callback on a value if the value is not null
+Invoke a callback on a value if the value is not null.
+
+``Function\with(mixed $value, callable $callback, bool $invokeValue = true, mixed $default = null): mixed``
 
 ```php
 <?php
@@ -514,6 +516,8 @@ $retval = with($value, function($value) {
 
 `with()` returns whatever the callback returns. In the above example
 `$retval` would be `'my_result'`.
+
+If the value of `$value` is `null`, `with()` will return `$default` which defaults to be `null`.
 
 ## invoke_if()
 

--- a/src/Functional/With.php
+++ b/src/Functional/With.php
@@ -30,14 +30,15 @@ use Functional\Exceptions\InvalidArgumentException;
  * @param mixed $value
  * @param callable $callback
  * @param bool $invokeValue Set to false to not invoke $value if it is a callable. Will be removed in 2.0
+ * @param mixed $default The default value to return if $value is null
  * @return mixed
  */
-function with($value, callable $callback, $invokeValue = true)
+function with($value, callable $callback, $invokeValue = true, $default = null)
 {
     InvalidArgumentException::assertCallback($callback, __FUNCTION__, 2);
 
     if ($value === null) {
-        return null;
+        return $default;
     }
 
     if ($invokeValue && \is_callable($value)) {

--- a/tests/Functional/WithTest.php
+++ b/tests/Functional/WithTest.php
@@ -73,4 +73,18 @@ class WithTest extends AbstractTestCase
         $this->expectArgumentError("Argument 2 passed to Functional\with() must be callable");
         with(null, 'undefinedFunction');
     }
+
+    public function testDefaultValue()
+    {
+        $this->assertSame(
+            'foo',
+            with(
+                null,
+                function () {
+                },
+                true,
+                'foo'
+            )
+        );
+    }
 }


### PR DESCRIPTION
As discussed, this PR allows `with()` to return a default when `$value` is null. 
There shouldn't be BC breaks.