### PR TITLE
Add `omit_keys` function.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
             "src/Functional/Minimum.php",
             "src/Functional/None.php",
             "src/Functional/Not.php",
+            "src/Functional/OmitKeys.php",
             "src/Functional/PartialAny.php",
             "src/Functional/PartialLeft.php",
             "src/Functional/PartialMethod.php",

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -37,6 +37,7 @@
   - [last_index_of()](#last_index_of)
   - [indexes_of()](#indexes_of)
   - [select_keys()](#select_keys)
+  - [omit_keys()](#omit_keys)
   - [take_left()](#take_left)
   - [take_right()](#take_right)
 - [Function functions](#function-functions)
@@ -627,7 +628,20 @@ Returns an array containing only those entries in the array/Traversable whose ke
 use function Functional\select_keys;
 
 // $array will be ['foo' => 1, 'baz' => 3]
-$array = select_keys(['foo' => 1, 'bar' => 2', 'baz' => 3], ['foo', 'baz']);
+$array = select_keys(['foo' => 1, 'bar' => 2, 'baz' => 3], ['foo', 'baz']);
+```
+
+## omit_keys()
+
+Returns an array containing only those entries in the array/Traversable whose key is not in the supplied keys.
+
+```php
+<?php
+
+use function Functional\omit_keys;
+
+// $array will be ['bar' => 2]
+$array = omit_keys(['foo' => 1, 'bar' => 2, 'baz' => 3], ['foo', 'baz']);
 ```
 
 ## take_left()

--- a/src/Functional/Functional.php
+++ b/src/Functional/Functional.php
@@ -278,6 +278,11 @@ final class Functional
     const not = '\Functional\not';
 
     /**
+     * @see \Functional\omit_keys
+     */
+    const omit_keys = '\Functional\omit_keys';
+
+    /**
      * @see \Functional\partial_any
      */
     const partial_any = '\Functional\partial_any';

--- a/src/Functional/OmitKeys.php
+++ b/src/Functional/OmitKeys.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @package   Functional-php
+ * @author    Lars Strojny <lstrojny@php.net>
+ * @copyright 2011-2017 Lars Strojny
+ * @license   https://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/lstrojny/functional-php
+ */
+
+namespace Functional;
+
+use Functional\Exceptions\InvalidArgumentException;
+use Traversable;
+
+/**
+ * Returns an array with the specified keys omitted from the array
+ *
+ * @param Traversable|array $collection
+ * @param array $keys
+ * @return array
+ */
+function omit_keys($collection, array $keys)
+{
+    InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
+
+    if ($collection instanceof Traversable) {
+        $array = \iterator_to_array($collection);
+    } else {
+        $array = $collection;
+    }
+
+    return \array_diff_key($array, \array_flip($keys));
+}

--- a/tests/Functional/OmitKeysTest.php
+++ b/tests/Functional/OmitKeysTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package   Functional-php
+ * @author    Lars Strojny <lstrojny@php.net>
+ * @copyright 2011-2017 Lars Strojny
+ * @license   https://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/lstrojny/functional-php
+ */
+
+namespace Functional\Tests;
+
+use ArrayIterator;
+
+use function Functional\omit_keys;
+
+class OmitKeysTest extends AbstractTestCase
+{
+    public static function getData()
+    {
+        return [
+            [['foo' => 1], ['foo' => 1], []],
+            [['foo' => 1], ['foo' => 1], ['bar']],
+            [[], ['foo' => 1], ['foo']],
+            [[], ['foo' => 1, 'bar' => 2], ['foo', 'bar']],
+            [['bar' => 2], ['foo' => 1, 'bar' => 2], ['foo']],
+            [[1 => 'b'], ['a', 'b', 'c'], [0, 2]],
+        ];
+    }
+
+    /**
+     * @dataProvider getData
+     */
+    public function test(array $expected, array $input, array $keys)
+    {
+        $this->assertSame($expected, omit_keys($input, $keys));
+        $this->assertSame($expected, omit_keys(new ArrayIterator($input), $keys));
+    }
+
+    public function testPassNonArrayOrTraversable()
+    {
+        $this->expectArgumentError("Functional\omit_keys() expects parameter 1 to be array or instance of Traversable");
+        omit_keys(new \stdclass(), []);
+    }
+}


### PR DESCRIPTION
This pull request adds the `omit_keys` function. I also considered naming the function `remove_keys`, `ignore_keys`, or [`dissoc`](http://clojuredocs.org/clojure.core/dissoc) (since the [`select_keys`](https://github.com/lstrojny/functional-php/blob/master/docs/functional-php.md#select_keys) function was [inspired by Clojure](https://github.com/lstrojny/functional-php/pull/145)).

Closes #203.