### PR TITLE
Add null to docblock of `minimum` and `maximum`.

### DIFF
--- a/src/Functional/Maximum.php
+++ b/src/Functional/Maximum.php
@@ -17,7 +17,7 @@ use Traversable;
  * Returns the maximum value of a collection
  *
  * @param Traversable|array $collection
- * @return integer|float
+ * @return integer|float|null
  */
 function maximum($collection)
 {

--- a/src/Functional/Minimum.php
+++ b/src/Functional/Minimum.php
@@ -17,7 +17,7 @@ use Traversable;
  * Returns the minimum value of a collection
  *
  * @param Traversable|array $collection
- * @return integer|float
+ * @return integer|float|null
  */
 function minimum($collection)
 {


### PR DESCRIPTION
The `minimum` and `maximum` functions can return null if the $collection is empty. This commit adds to their @return annotation that a null return is a possibility.

I'm not sure if this relates to #208, but _psalm_ does report handling the possibility of a null return with [`DocblockTypeContradiction`](https://psalm.dev/docs/running_psalm/issues/#docblocktypecontradiction).  

For example, `maximum([]) ?? -1` will produce a `DocblockTypeContradiction`.