### PR TITLE
Make default callback the identity function.

### DIFF
--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -94,7 +94,7 @@ map(range(0, 100), function($v) {return $v + 1;});
 
 ## every() & invoke()
 
-``Functional\every(array|Traversable $collection, callable $callback)``
+``Functional\every(array|Traversable $collection, callable $callback = null)``
 
 ```php
 <?php
@@ -107,11 +107,11 @@ if (every($users, function($user, $collectionKey, $collection) {return $user->is
 }
 ```
 
-The default value for $callback is `id()`.
+If `$callback` is not provided then the `id()` function is used and `every` will return true if every value in the collection is truthy.
 
 ## some()
 
-``bool Functional\some(array|Traversable $collection, callable $callback)``
+``bool Functional\some(array|Traversable $collection, callable $callback = null)``
 
 ```php
 <?php
@@ -122,7 +122,7 @@ if (some($users, function($user, $collectionKey, $collection) use($me) {return $
 }
 ```
 
-The default value for $callback is `id()`.
+If `$callback` is not provided then the `id()` function is used and `some` will return true if at least one value in the collection is truthy.
 
 ## none()
 
@@ -137,13 +137,13 @@ if (none($users, function($user, $collectionKey, $collection) {return $user->isA
 }
 ```
 
-The default value for $callback is `id()`.
+If `$callback` is not provided then the `id()` function is used and `none` will return true if every value in the collection is falsey.
 
 ## reject() & select()
 
-``array Functional\select(array|Traversable $collection, callable $callback)``
+``array Functional\select(array|Traversable $collection, callable $callback = null)``
 
-``array Functional\reject(array|Traversable $collection, callable $callback)``
+``array Functional\reject(array|Traversable $collection, callable $callback = null)``
 
 ```php
 <?php
@@ -157,7 +157,9 @@ $activeUsers = select($users, $fn);
 $inactiveUsers = reject($users, $fn);
 ```
 
-For both functions, array keys are preserved and the default value for $callback is `id()`.  
+For both functions array keys are preserved.
+
+For both functions if a value for $callback is not provided then the `id()` function is used. For `select`, this means that only the truthy values in the collection will be returned. For `reject`, this means that only the falsey values in the collection will be returned.
 
 Alias for `Functional\select()` is `Functional\filter()`
 

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -107,6 +107,7 @@ if (every($users, function($user, $collectionKey, $collection) {return $user->is
 }
 ```
 
+The default value for $callback is `id()`.
 
 ## some()
 
@@ -121,6 +122,7 @@ if (some($users, function($user, $collectionKey, $collection) use($me) {return $
 }
 ```
 
+The default value for $callback is `id()`.
 
 ## none()
 
@@ -135,6 +137,7 @@ if (none($users, function($user, $collectionKey, $collection) {return $user->isA
 }
 ```
 
+The default value for $callback is `id()`.
 
 ## reject() & select()
 
@@ -153,6 +156,8 @@ $fn = function($user, $collectionKey, $collection) {
 $activeUsers = select($users, $fn);
 $inactiveUsers = reject($users, $fn);
 ```
+
+For both functions, array keys are preserved and the default value for $callback is `id()`.  
 
 Alias for `Functional\select()` is `Functional\filter()`
 

--- a/src/Functional/Every.php
+++ b/src/Functional/Every.php
@@ -18,12 +18,16 @@ use Traversable;
  * Callback arguments will be element, index, collection
  *
  * @param Traversable|array $collection
- * @param callable $callback
+ * @param callable|null $callback
  * @return bool
  */
-function every($collection, callable $callback)
+function every($collection, callable $callback = null)
 {
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
+
+    if ($callback === null) {
+        $callback = '\Functional\id';
+    }
 
     foreach ($collection as $index => $element) {
         if (!$callback($element, $index, $collection)) {

--- a/src/Functional/None.php
+++ b/src/Functional/None.php
@@ -18,12 +18,16 @@ use Traversable;
  * Callback arguments will be element, index, collection.
  *
  * @param Traversable|array $collection
- * @param callable $callback
+ * @param callable|null $callback
  * @return bool
  */
-function none($collection, callable $callback)
+function none($collection, callable $callback = null)
 {
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
+
+    if ($callback === null) {
+        $callback = '\Functional\id';
+    }
 
     foreach ($collection as $index => $element) {
         if ($callback($element, $index, $collection)) {

--- a/src/Functional/Reject.php
+++ b/src/Functional/Reject.php
@@ -18,14 +18,18 @@ use Traversable;
  * Functional\select(). Callback arguments will be element, index, collection
  *
  * @param Traversable|array $collection
- * @param callable $callback
+ * @param callable|null $callback
  * @return array
  */
-function reject($collection, callable $callback)
+function reject($collection, callable $callback = null)
 {
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     $aggregation = [];
+
+    if ($callback === null) {
+        $callback = '\Functional\id';
+    }
 
     foreach ($collection as $index => $element) {
         if (!$callback($element, $index, $collection)) {

--- a/src/Functional/Select.php
+++ b/src/Functional/Select.php
@@ -18,14 +18,18 @@ use Traversable;
  * Opposite is Functional\reject(). Callback arguments will be element, index, collection
  *
  * @param Traversable|array $collection
- * @param callable $callback
+ * @param callable|null $callback
  * @return array
  */
-function select($collection, callable $callback)
+function select($collection, callable $callback = null)
 {
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
 
     $aggregation = [];
+
+    if ($callback === null) {
+        $callback = '\Functional\id';
+    }
 
     foreach ($collection as $index => $element) {
         if ($callback($element, $index, $collection)) {

--- a/src/Functional/Some.php
+++ b/src/Functional/Some.php
@@ -18,12 +18,16 @@ use Traversable;
  * traversing the collection if a truthy element is found. Callback arguments will be value, index, collection
  *
  * @param Traversable|array $collection
- * @param callable $callback
+ * @param callable|null $callback
  * @return bool
  */
-function some($collection, callable $callback)
+function some($collection, callable $callback = null)
 {
     InvalidArgumentException::assertCollection($collection, __FUNCTION__, 1);
+
+    if ($callback === null) {
+        $callback = '\Functional\id';
+    }
 
     foreach ($collection as $index => $element) {
         if ($callback($element, $index, $collection)) {

--- a/tests/Functional/EveryTest.php
+++ b/tests/Functional/EveryTest.php
@@ -46,6 +46,14 @@ class EveryTest extends AbstractTestCase
         every('invalidCollection', 'strlen');
     }
 
+    public function testPassNoCallable()
+    {
+        $this->assertTrue(every($this->goodArray));
+        $this->assertTrue(every($this->goodIterator));
+        $this->assertTrue(every($this->badArray));
+        $this->assertTrue(every($this->badIterator));
+    }
+
     public function testExceptionIsThrownInArray()
     {
         $this->expectException('DomainException');

--- a/tests/Functional/NoneTest.php
+++ b/tests/Functional/NoneTest.php
@@ -46,6 +46,14 @@ class NoneTest extends AbstractTestCase
         none($this->goodArray, 'undefinedFunction');
     }
 
+    public function testPassNoCallable()
+    {
+        $this->assertFalse(none($this->goodArray));
+        $this->assertFalse(none($this->goodIterator));
+        $this->assertFalse(none($this->badArray));
+        $this->assertFalse(none($this->badIterator));
+    }
+
     public function testExceptionIsThrownInArray()
     {
         $this->expectException('DomainException');

--- a/tests/Functional/RejectTest.php
+++ b/tests/Functional/RejectTest.php
@@ -44,6 +44,15 @@ class RejectTest extends AbstractTestCase
         reject($this->list, 'undefinedFunction');
     }
 
+    public function testPassNoCallable()
+    {
+        $this->assertSame([], reject($this->list));
+        $this->assertSame([], reject($this->listIterator));
+        $this->assertSame([], reject($this->hash));
+        $this->assertSame([], reject($this->hashIterator));
+        $this->assertSame([1 => false], reject([true, false, true]));
+    }
+
     public function testPassNoCollection()
     {
         $this->expectArgumentError('Functional\reject() expects parameter 1 to be array or instance of Traversable');

--- a/tests/Functional/SelectTest.php
+++ b/tests/Functional/SelectTest.php
@@ -64,6 +64,15 @@ class SelectTest extends AbstractTestCase
         $functionName($this->list, 'undefinedFunction');
     }
 
+    public function testPassNoCallable()
+    {
+        $this->assertSame(['value', 'wrong', 'value'], select($this->list));
+        $this->assertSame(['value', 'wrong', 'value'], select($this->listIterator));
+        $this->assertSame(['k1' => 'value', 'k2' => 'wrong', 'k3' => 'value'], select($this->hash));
+        $this->assertSame(['k1' => 'value', 'k2' => 'wrong', 'k3' => 'value'], select($this->hashIterator));
+        $this->assertSame([0 => true, 2 => true], select([true, false, true]));
+    }
+
     /**
      * @dataProvider getAliases
      */

--- a/tests/Functional/SomeTest.php
+++ b/tests/Functional/SomeTest.php
@@ -40,6 +40,14 @@ class SomeTest extends AbstractTestCase
         some($this->goodArray, 'undefinedFunction');
     }
 
+    public function testPassNoCallable()
+    {
+        $this->assertTrue(some($this->goodArray));
+        $this->assertTrue(some($this->goodIterator));
+        $this->assertTrue(some($this->badArray));
+        $this->assertTrue(some($this->badIterator));
+    }
+
     public function testPassNoCollection()
     {
         $this->expectArgumentError('Functional\some() expects parameter 1 to be array or instance of Traversable');


### PR DESCRIPTION
This pull request updates the `select`, `reject`, `some`, `none`, and `every` functions so that the default callback argument is the `id` function. 

PHP allows only `null` to be set as the default value of a `callable` argument. This requires a null check in the body of each function.

