### PR TITLE
Add `ary` function which ignores arguments over the supplied number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "autoload": {
         "psr-4": {"Functional\\": "src/Functional"},
         "files": [
+            "src/Functional/Ary.php",
             "src/Functional/Average.php",
             "src/Functional/ButLast.php",
             "src/Functional/Capture.php",

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -356,6 +356,26 @@ $partiallyAppliedSubtractor = partial_right($subtractor, 10);
 $partiallyAppliedSubtractor(20); // -> 10
 ```
 
+## ary()
+
+`Functional\ary` (as in arity) takes a `callable` and a count and calls the `callable` with 
+that many arguments using `take_left` if positive, or `take_right` if negative. 
+Throws if passed 0.
+
+For example:
+
+```php
+use function Functional\ary;
+use function Functional\map;
+
+# This fails because map calls it's callable with the element, 
+# index and the whole collection
+# map($array, 'ucfirst');
+
+# Using `ary`
+map($array, ary('ucfirst', 1')); # Passes only the first argument to `ucfirst`
+```
+
 ## partial_any()
 
 There is a third function in the family called `partial_any`. Unlike its siblings it doesn’t automatically merge but it

--- a/src/Functional/Ary.php
+++ b/src/Functional/Ary.php
@@ -23,9 +23,9 @@ function ary(callable $func, int $count): callable
 
     return function (...$args) use ($func, $count) {
         if ($count > 0) {
-            return $func(take_left($args, $count));
+            return $func(...take_left($args, $count));
         } else if ($count < 0) {
-            return $func(take_right($args, -$count));
+            return $func(...take_right($args, -$count));
         }
     };
 }

--- a/src/Functional/Ary.php
+++ b/src/Functional/Ary.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @package   Functional-php
+ * @author    Hugo Sales <hugo@fc.up.pt>
+ * @copyright 2020 Hugo Sales
+ * @license   https://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/lstrojny/functional-php
+ */
+
+namespace Functional;
+
+use Functional\Exceptions\InvalidArgumentException;
+use Traversable;
+
+/**
+ * Call $func with only abs($count) arguments, taken either from the
+ * left or right depending on the sign
+ */
+function ary(callable $func, int $count): callable
+{
+    InvalidArgumentException::assertNonZeroInteger($count, __FUNCTION__);
+
+    return function (...$args) use ($func, $count) {
+        if ($count > 0) {
+            return $func(take_left($args, $count));
+        } else if ($count < 0) {
+            return $func(take_right($args, -$count));
+        }
+    };
+}

--- a/src/Functional/Exceptions/InvalidArgumentException.php
+++ b/src/Functional/Exceptions/InvalidArgumentException.php
@@ -280,7 +280,7 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
-    private static function assertNonZeroInteger($value, $callee)
+    public static function assertNonZeroInteger($value, $callee)
     {
         if (!\is_int($value) || $value == 0) {
             throw new static(\sprintf('%s expected parameter %d to be non-zero', $callee, $value));

--- a/src/Functional/Exceptions/InvalidArgumentException.php
+++ b/src/Functional/Exceptions/InvalidArgumentException.php
@@ -280,6 +280,16 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    private static function assertNonZeroInteger($value, $callee) {
+        if (!\is_int($value) || $value == 0) {
+            throw new static(
+                \sprintf(
+                    '%s expected parameter %d to be non-zero', $callee, $value
+                )
+            );
+        }
+    }
+
     private static function getType($value)
     {
         return \is_object($value) ? \get_class($value) : \gettype($value);

--- a/src/Functional/Exceptions/InvalidArgumentException.php
+++ b/src/Functional/Exceptions/InvalidArgumentException.php
@@ -280,13 +280,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
-    private static function assertNonZeroInteger($value, $callee) {
+    private static function assertNonZeroInteger($value, $callee)
+    {
         if (!\is_int($value) || $value == 0) {
-            throw new static(
-                \sprintf(
-                    '%s expected parameter %d to be non-zero', $callee, $value
-                )
-            );
+            throw new static(\sprintf('%s expected parameter %d to be non-zero', $callee, $value));
         }
     }
 

--- a/src/Functional/Functional.php
+++ b/src/Functional/Functional.php
@@ -12,6 +12,12 @@ namespace Functional;
 
 final class Functional
 {
+
+    /**
+     * @see \Function\ary
+     */
+    const ary = '\Functional\ary';
+
     /**
      * @see \Functional\average
      */

--- a/tests/Functional/AryTest.php
+++ b/tests/Functional/AryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @package   Functional-php
+ * @author    Hugo Sales <hugo@fc.up.pt>
+ * @copyright 2020 Hugo Sales
+ * @license   https://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/lstrojny/functional-php
+ */
+
+namespace Functional\Tests;
+
+use function Functional\ary;
+
+class AryTest extends AbstractTestCase
+{
+
+    public function test()
+    {
+        $this->assertSame(5, ary(function ($a = 0, $b = 0) { return $a + $b; }, 1)(5));
+        $this->assertSame(5, ary(function ($a = 0, $b = 0, $c = 0) { return $a + $b + $c; }, 1)(5));
+        $this->assertSame(6, ary(function ($a = 0, $b = 0, $c = 0) { return $a + $b + $c; }, -1)(6));
+        $this->assertSame(7, ary(function ($a = 0, $b = 0, $c = 0) { return $a + $b + $c; }, 2)(5, 2));
+        $this->assertNull(ary(function ($a = 0, $b = 0) { return $a + $b; }, 0)(5));
+    }
+}

--- a/tests/Functional/AryTest.php
+++ b/tests/Functional/AryTest.php
@@ -17,10 +17,14 @@ class AryTest extends AbstractTestCase
 
     public function test()
     {
-        $this->assertSame(5, ary(function ($a = 0, $b = 0) { return $a + $b; }, 1)(5));
-        $this->assertSame(5, ary(function ($a = 0, $b = 0, $c = 0) { return $a + $b + $c; }, 1)(5));
-        $this->assertSame(6, ary(function ($a = 0, $b = 0, $c = 0) { return $a + $b + $c; }, -1)(6));
-        $this->assertSame(7, ary(function ($a = 0, $b = 0, $c = 0) { return $a + $b + $c; }, 2)(5, 2));
-        $this->assertNull(ary(function ($a = 0, $b = 0) { return $a + $b; }, 0)(5));
+        $f = function ($a = 0, $b = 0, $c = 0) {
+            return $a + $b + $c;
+        };
+
+        $this->assertSame(5, ary($f, 1)(5));
+        $this->assertSame(5, ary($f, 1)(5));
+        $this->assertSame(6, ary($f, -1)(6));
+        $this->assertSame(7, ary($f, 2)(5, 2));
+        $this->assertNull(ary($f, 0)(5));
     }
 }

--- a/tests/Functional/AryTest.php
+++ b/tests/Functional/AryTest.php
@@ -11,6 +11,7 @@
 namespace Functional\Tests;
 
 use function Functional\ary;
+use Functional\Exceptions\InvalidArgumentException;
 
 class AryTest extends AbstractTestCase
 {
@@ -21,10 +22,20 @@ class AryTest extends AbstractTestCase
             return $a + $b + $c;
         };
 
+        $this->assertSame(5, $f(5));
         $this->assertSame(5, ary($f, 1)(5));
         $this->assertSame(5, ary($f, 1)(5));
         $this->assertSame(6, ary($f, -1)(6));
         $this->assertSame(7, ary($f, 2)(5, 2));
-        $this->assertNull(ary($f, 0)(5));
+    }
+
+    public function testException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $f = function ($a = 0, $b = 0, $c = 0) {
+            return $a + $b + $c;
+        };
+
+        ary($f, 0)(5);
     }
 }


### PR DESCRIPTION
Added function which defines a function of an arbitry number of arguments and
calls the provided callable with only the given number of arguments

Didn't add tests as it wasn't obvious how they worked and wanted feedback before investing the time