### PR TITLE
Prevent hash collisions for object hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
-sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    - vendor
 
 php:
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
             "src/Functional/True.php",
             "src/Functional/Truthy.php",
             "src/Functional/Unique.php",
+            "src/Functional/ValueToKey.php",
             "src/Functional/With.php",
             "src/Functional/Zip.php",
             "src/Functional/ZipAll.php"

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -904,7 +904,7 @@ var_dump($is_odd(2)); // false
 
 ## Other
 
-`mixed Functional\memoize(callable $callback[, array $arguments = []], [mixed $key = null]])`
+`mixed Functional\memoize(callable $callback[, array $arguments = []], [string|array $key = null]])`
 Returns and stores the result of the function call. Second call to the same function will return the same result without calling the function again
 
 # Mathematical functions

--- a/docs/functional-php.md
+++ b/docs/functional-php.md
@@ -21,6 +21,7 @@
 - [Partial application](#partial-application)
   - [Introduction](#introduction)
   - [partial_left() & partial_right()](#partial_left--partial_right)
+  - [ary()](#ary)
   - [partial_any()](#partial_any)
   - [partial_method()](#partial_method)
   - [converge()](#converge)
@@ -49,7 +50,8 @@
   - [compose()](#compose)
   - [tail_recursion()](#tail_recursion)
   - [flip()](#flip)
-  - [Other](#other)
+  - [not](#not)
+  - [Other](#other-1)
 - [Mathematical functions](#mathematical-functions)
 - [Transformation functions](#transformation-functions)
   - [partition()](#partition)
@@ -58,13 +60,14 @@
   - [flatten()](#flatten)
   - [reduce_left() & reduce_right()](#reduce_left--reduce_right)
   - [intersperse()](#intersperse)
-  - [Other](#other-1)
+  - [Other](#other-2)
 - [Conditional functions](#conditional-functions)
   - [if_else()](#if_else)
   - [match()](#match)
 - [Higher order comparison functions](#higher-order-comparison-functions)
-  - [compare_on() & compare_object_hash_on()](#compare_on--compare_object_hash_on)
+  - [compare_on & compare_object_hash_on](#compare_on--compare_object_hash_on)
 - [Miscellaneous](#miscellaneous)
+  - [concat()](#concat)
   - [const_function()](#const_function)
   - [id()](#id)
   - [tap()](#tap)
@@ -906,6 +909,9 @@ var_dump($is_odd(2)); // false
 
 `mixed Functional\memoize(callable $callback[, array $arguments = []], [string|array $key = null]])`
 Returns and stores the result of the function call. Second call to the same function will return the same result without calling the function again
+
+`string value_to_key(...$values)`
+Builds an array key out of any values, correctly handling object identity and traversables. Resources are not supported
 
 # Mathematical functions
 

--- a/src/Functional/Functional.php
+++ b/src/Functional/Functional.php
@@ -475,6 +475,11 @@ final class Functional
     const unique = '\Functional\unique';
 
     /**
+     * @see \Functional\value_to_key
+     */
+    const value_to_key = '\Functional\value_to_key';
+
+    /**
      * @see \Functional\with
      */
     const with = '\Functional\with';

--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -10,6 +10,8 @@
 
 namespace Functional;
 
+use const E_USER_DEPRECATED;
+
 /**
  * Memoizes callbacks and returns their value instead of calling them
  *
@@ -18,7 +20,7 @@ namespace Functional;
  * @param array|string $key Optional memoize key to override the auto calculated hash
  * @return mixed
  */
-function memoize(callable $callback = null, array $arguments = [], $key = null)
+function memoize(callable $callback = null, $arguments = [], $key = null)
 {
     static $storage = [];
     if ($callback === null) {
@@ -27,10 +29,16 @@ function memoize(callable $callback = null, array $arguments = [], $key = null)
         return null;
     }
 
+    if (\is_callable($key)) {
+        \trigger_error('Passing a callable as key is deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+        $key = $key();
+    } elseif (\is_callable($arguments)) {
+        \trigger_error('Passing a callable as key is deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+        $key = $arguments();
+    }
+
     if ($key === null) {
         $key = value_to_key(\array_merge([$callback], $arguments));
-    } elseif (\is_callable($key)) {
-        $key = value_to_key($key());
     } else {
         $key = value_to_key($key);
     }

--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -11,6 +11,7 @@
 namespace Functional;
 
 use Functional\Exceptions\InvalidArgumentException;
+use WeakReference;
 
 /**
  * Memoizes callbacks and returns their value instead of calling them
@@ -23,6 +24,7 @@ use Functional\Exceptions\InvalidArgumentException;
 function memoize(callable $callback = null, $arguments = [], $key = null)
 {
     static $storage = [];
+    static $objectRefs = [];
 
     if ($callback === null) {
         $storage = [];
@@ -39,12 +41,34 @@ function memoize(callable $callback = null, $arguments = [], $key = null)
 
     static $keyGenerator = null;
     if (!$keyGenerator) {
-        $keyGenerator = function ($value) use (&$keyGenerator) {
+        $keyGenerator = static function ($value) use (&$keyGenerator, &$objectRefs) {
             $type = \gettype($value);
             if ($type === 'array') {
-                $key = \join(':', map($value, $keyGenerator));
+                $key = \implode(':', map($value, $keyGenerator));
             } elseif ($type === 'object') {
-                $key = \get_class($value) . ':' . \spl_object_hash($value);
+                $hash = \spl_object_hash($value);
+                if (PHP_VERSION_ID >= 70400) {
+                    /** @var WeakReference[] $objectRefs */
+                    static $objectRefs = [];
+                    /** @var int[] $collisions */
+                    static $collisions = [];
+
+                    if (isset($objectRefs[$hash])) {
+                        if ($objectRefs[$hash]->get() === null) {
+                            $collisions[$hash] = ($collisions[$hash] ?? 0) + 1;
+                            $objectRefs[$hash] = WeakReference::create($value);
+                        }
+                    } else {
+                        $objectRefs[$hash] = WeakReference::create($value);
+                    }
+
+                    $key = \get_class($value) . ':' . $hash . ':' . ($collisions[$hash] ?? 0);
+                } else {
+                    // For PHP < 7.4 we keep a static reference to the object so that cannot accidentally go out of
+                    // scope and mess with the object hashes
+                    $objectRefs[$hash] = $value;
+                    $key = \get_class($value) . ':' . \spl_object_hash($value);
+                }
             } else {
                 $key = (string) $value;
             }

--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -12,6 +12,7 @@ namespace Functional;
 
 use Functional\Exceptions\InvalidArgumentException;
 use WeakReference;
+use function is_callable;
 
 /**
  * Memoizes callbacks and returns their value instead of calling them
@@ -21,78 +22,21 @@ use WeakReference;
  * @param array|string $key Optional memoize key to override the auto calculated hash
  * @return mixed
  */
-function memoize(callable $callback = null, $arguments = [], $key = null)
+function memoize(callable $callback = null, array $arguments = [], $key = null)
 {
     static $storage = [];
-    /** @var object[]|WeakReference[] $objectRefs */
-    static $objectRefs = [];
-
     if ($callback === null) {
         $storage = [];
 
         return null;
     }
 
-    if (\is_callable($arguments)) {
-        $key = $arguments;
-        $arguments = [];
-    } else {
-        InvalidArgumentException::assertCollection($arguments, __FUNCTION__, 2);
-    }
-
-    static $keyGenerator = null;
-    if (!$keyGenerator) {
-        $keyGenerator = static function ($value) use (&$keyGenerator, &$objectRefs) {
-            $type = \gettype($value);
-            if ($type === 'array') {
-                $key = \implode(':', map($value, $keyGenerator));
-            } elseif ($type === 'object') {
-                $hash = \spl_object_hash($value);
-                /**
-                 * spl_object_hash() will return the same hash twice in a single request if an object goes out of scope
-                 * and is destructed.
-                 */
-                if (PHP_VERSION_ID >= 70400) {
-                    /**
-                     * For PHP >=7.4, we keep a weak reference to the relevant object that we use for hashing. Once the
-                     * object gets out of scope, the weak ref will no longer return the object, that’s how we know we
-                     * have a collision and increment a version in the collisions array.
-                     */
-                    /** @var int[] $collisions */
-                    static $collisions = [];
-
-                    if (isset($objectRefs[$hash])) {
-                        if ($objectRefs[$hash]->get() === null) {
-                            $collisions[$hash] = ($collisions[$hash] ?? 0) + 1;
-                            $objectRefs[$hash] = WeakReference::create($value);
-                        }
-                    } else {
-                        $objectRefs[$hash] = WeakReference::create($value);
-                    }
-
-                    $key = \get_class($value) . ':' . $hash . ':' . ($collisions[$hash] ?? 0);
-                } else {
-                    /**
-                     * For PHP < 7.4 we keep a static reference to the object so that cannot accidentally go out of
-                     * scope and mess with the object hashes
-                     */
-                    $objectRefs[$hash] = $value;
-                    $key = \get_class($value) . ':' . \spl_object_hash($value);
-                }
-            } else {
-                $key = (string) $value;
-            }
-
-            return $key;
-        };
-    }
-
     if ($key === null) {
-        $key = $keyGenerator(\array_merge([$callback], $arguments));
+        $key = value_to_key(\array_merge([$callback], $arguments));
     } elseif (\is_callable($key)) {
-        $key = $keyGenerator($key());
+        $key = value_to_key($key());
     } else {
-        $key = $keyGenerator($key);
+        $key = value_to_key($key);
     }
 
     if (!isset($storage[$key]) && !\array_key_exists($key, $storage)) {

--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -24,6 +24,7 @@ use WeakReference;
 function memoize(callable $callback = null, $arguments = [], $key = null)
 {
     static $storage = [];
+    /** @var object[]|WeakReference[] $objectRefs */
     static $objectRefs = [];
 
     if ($callback === null) {
@@ -57,8 +58,6 @@ function memoize(callable $callback = null, $arguments = [], $key = null)
                      * object gets out of scope, the weak ref will no longer return the object, that’s how we know we
                      * have a collision and increment a version in the collisions array.
                      */
-                    /** @var WeakReference[] $objectRefs */
-                    static $objectRefs = [];
                     /** @var int[] $collisions */
                     static $collisions = [];
 

--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -10,10 +10,6 @@
 
 namespace Functional;
 
-use Functional\Exceptions\InvalidArgumentException;
-use WeakReference;
-use function is_callable;
-
 /**
  * Memoizes callbacks and returns their value instead of calling them
  *

--- a/src/Functional/ValueToKey.php
+++ b/src/Functional/ValueToKey.php
@@ -77,7 +77,7 @@ function value_to_key(...$any)
                     'Resource type cannot be used as part of a memoization key. Please pass a custom key instead'
                 );
             } else {
-                $ref = serialize($value);
+                $ref = \serialize($value);
             }
 
             return ($key !== null ? ($valueToRef($key) . '~') : '') . $ref;

--- a/src/Functional/ValueToKey.php
+++ b/src/Functional/ValueToKey.php
@@ -56,7 +56,7 @@ function value_to_key(...$any)
                  * scope and mess with the object hashes
                  */
                 $objectReferences[$hash] = $value;
-                $key = \get_class($value) . ':' . \spl_object_hash($value);
+                $key = \get_class($value) . ':' . $hash;
             }
             return $key;
         };

--- a/src/Functional/ValueToKey.php
+++ b/src/Functional/ValueToKey.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @package   Functional-php
+ * @author    Lars Strojny <lstrojny@php.net>
+ * @copyright 2011-2017 Lars Strojny
+ * @license   https://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/lstrojny/functional-php
+ */
+
+namespace Functional;
+
+use Functional\Exceptions\InvalidArgumentException;
+use Traversable;
+use WeakReference;
+
+use function serialize;
+
+use const PHP_VERSION_ID;
+
+function value_to_key(...$any)
+{
+    /** @var object[]|WeakReference[] $objectReferences */
+    static $objectReferences = [];
+
+    static $objectToRef = null;
+    if (!$objectToRef) {
+        $objectToRef = static function ($value) use (&$objectReferences) {
+            $hash = \spl_object_hash($value);
+            /**
+             * spl_object_hash() will return the same hash twice in a single request if an object goes out of scope
+             * and is destructed.
+             */
+            if (PHP_VERSION_ID >= 70400) {
+                /**
+                 * For PHP >=7.4, we keep a weak reference to the relevant object that we use for hashing. Once the
+                 * object gets out of scope, the weak ref will no longer return the object, that’s how we know we
+                 * have a collision and increment a version in the collisions array.
+                 */
+                /** @var int[] $collisions */
+                static $collisions = [];
+
+                if (isset($objectReferences[$hash])) {
+                    if ($objectReferences[$hash]->get() === null) {
+                        $collisions[$hash] = ($collisions[$hash] ?? 0) + 1;
+                        $objectReferences[$hash] = WeakReference::create($value);
+                    }
+                } else {
+                    $objectReferences[$hash] = WeakReference::create($value);
+                }
+
+                $key = \get_class($value) . ':' . $hash . ':' . ($collisions[$hash] ?? 0);
+            } else {
+                /**
+                 * For PHP < 7.4 we keep a static reference to the object so that cannot accidentally go out of
+                 * scope and mess with the object hashes
+                 */
+                $objectReferences[$hash] = $value;
+                $key = \get_class($value) . ':' . \spl_object_hash($value);
+            }
+            return $key;
+        };
+    }
+
+    static $valueToRef = null;
+    if (!$valueToRef) {
+        $valueToRef = static function ($value, $key = null) use (&$valueToRef, $objectToRef) {
+            $type = \gettype($value);
+            if ($type === 'array') {
+                $ref = '[' . \implode(':', map($value, $valueToRef)) . ']';
+            } elseif ($value instanceof Traversable) {
+                $ref = $objectToRef($value) . '[' . \implode(':', map($value, $valueToRef)) . ']';
+            } elseif ($type === 'object') {
+                $ref = $objectToRef($value);
+            } elseif ($type === 'resource') {
+                throw new InvalidArgumentException(
+                    'Resource type cannot be used as part of a memoization key. Please pass a custom key instead'
+                );
+            } else {
+                $ref = serialize($value);
+            }
+
+            return ($key !== null ? ($valueToRef($key) . '~') : '') . $ref;
+        };
+    }
+
+    return $valueToRef($any);
+}

--- a/tests/Functional/MemoizeTest.php
+++ b/tests/Functional/MemoizeTest.php
@@ -13,6 +13,7 @@ namespace Functional\Tests;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use BadMethodCallException;
 use RuntimeException;
+
 use function Functional\memoize;
 
 function testfunc()

--- a/tests/Functional/MemoizeTest.php
+++ b/tests/Functional/MemoizeTest.php
@@ -124,7 +124,6 @@ class MemoizeTest extends AbstractTestCase
 
         $this->assertSame('FOO BAR', memoize([$this->callback, 'execute'], ['FOO', 'BAR'], 'MY:CUSTOM:KEY'));
         $this->assertSame('FOO BAR', memoize([$this->callback, 'execute'], ['BAR', 'BAZ'], 'MY:CUSTOM:KEY'), 'Result already memoized');
-        $this->assertSame('FOO BAR', memoize([$this->callback, 'execute'], ['BAR', 'BAZ'], ['MY', 'CUSTOM', 'KEY']), 'Result already memoized');
 
         $this->assertSame('BAR BAZ', memoize([$this->callback, 'execute'], ['BAR', 'BAZ'], 'MY:DIFFERENT:KEY'));
         $this->assertSame('BAR BAZ', memoize([$this->callback, 'execute'], ['BAR', 'BAZ'], 'MY:DIFFERENT:KEY'), 'Result already memoized');
@@ -149,25 +148,6 @@ class MemoizeTest extends AbstractTestCase
             $this->fail('Expected failure');
         } catch (BadMethodCallException $e) {
         }
-    }
-
-    public function testPassKeyGeneratorCallable()
-    {
-        $this->callback
-            ->expects($this->exactly(2))
-            ->method('execute');
-
-        $keyGenerator = function () {
-            static $index;
-            return ($index++ % 2) === 0;
-        };
-
-        memoize([$this->callback, 'execute'], $keyGenerator);
-        memoize([$this->callback, 'execute'], [], $keyGenerator);
-        memoize([$this->callback, 'execute'], [], $keyGenerator);
-        memoize([$this->callback, 'execute'], $keyGenerator);
-        memoize([$this->callback, 'execute'], $keyGenerator);
-        memoize([$this->callback, 'execute'], [], $keyGenerator);
     }
 
     public function testResetByPassingNullAsCallable()

--- a/tests/Functional/ValueToKeyTest.php
+++ b/tests/Functional/ValueToKeyTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * @package   Functional-php
+ * @author    Lars Strojny <lstrojny@php.net>
+ * @copyright 2011-2017 Lars Strojny
+ * @license   https://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/lstrojny/functional-php
+ */
+
+namespace Functional\Tests;
+
+use ArrayObject;
+use Functional\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\Constraint\Constraint;
+use stdClass;
+use function Functional\ary;
+use function Functional\filter;
+use function Functional\pluck;
+use function Functional\value_to_key;
+use function preg_match;
+use function random_bytes;
+use function stream_context_create;
+use const PHP_VERSION_ID;
+
+class ValueToKeyTest extends AbstractTestCase
+{
+    const OBJECT_REF_REGEX = '@^\[i:0;~%s:(?<hash>[^\[:]+)(:\d+)?(\[.*])?\]$@';
+
+    public static function getSimpleTypeExpectations(): array
+    {
+        $binary = random_bytes(10);
+
+        return [
+            'Nothing' => [[], '[]'],
+            'NULL' => [[null], '[i:0;~N;]'],
+            'null string' => [['null'], '[i:0;~s:4:"null";]'],
+            'string' => [['string'], '[i:0;~s:6:"string";]'],
+            'integers' => [[12, 123], '[i:0;~i:12;:i:1;~i:123;]'],
+            'integer & float' => [[12, 123.10], '[i:0;~i:12;:i:1;~d:123.1;]'],
+            'array of string' => [[['foo', 'bar']], '[i:0;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";]]'],
+            'nested array of strings (1)' => [
+                [['foo', 'bar', ['foo', 'bar']]],
+                '[i:0;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";:i:2;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";]]]',
+            ],
+            'nested array of strings (variation)' => [
+                [['foo', 'bar', ['foo', ['bar']]]],
+                '[i:0;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";:i:2;~[i:0;~s:3:"foo";:i:1;~[i:0;~s:3:"bar";]]]]',
+            ],
+            'multiple nested arrays of strings' => [
+                [['foo', 'bar', ['foo', ['bar'], 'baz']]],
+                '[i:0;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";:i:2;~[i:0;~s:3:"foo";:i:1;~[i:0;~s:3:"bar";]:i:2;~s:3:"baz";]]]',
+            ],
+            'multiple nested arrays of strings (variation)' => [
+                [['foo', 'bar', ['foo', ['bar', 'baz']]]],
+                '[i:0;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";:i:2;~[i:0;~s:3:"foo";:i:1;~[i:0;~s:3:"bar";:i:1;~s:3:"baz";]]]]',
+            ],
+            'hashes' => [[['foo' => 'bar']], '[i:0;~[s:3:"foo";~s:3:"bar";]]'],
+            [[$binary], '[i:0;~s:10:"' . $binary . '";]'],
+            [[new stdClass()], self::matchesRegularExpression(self::createObjectRefRegex('stdClass'))],
+            [[new ArrayObject()], self::matchesRegularExpression(self::createObjectRefRegex('ArrayObject'))],
+        ];
+    }
+
+    /** @dataProvider getSimpleTypeExpectations */
+    public function testValueToRefOnSimpleTypes(array $input, $constraint)
+    {
+        $ref = value_to_key(...$input);
+        self::assertThat($ref, $constraint instanceof Constraint ? $constraint: self::identicalTo($constraint));
+
+        $hash[$ref] = 'value';
+        self::assertSame('value', $hash[$ref], 'Ref can be used as an array key');
+    }
+
+    public function testExpectationsAreNonIdentical()
+    {
+        $strings = filter(pluck(self::getSimpleTypeExpectations(), 1), ary('is_string', 1));
+        while ($string = array_pop($strings)) {
+            foreach ($strings as $otherString) {
+                if ($string === $otherString) {
+                    self::fail($string);
+                }
+            }
+        }
+        self::assertTrue(true, 'All expectations are different');
+    }
+
+    public static function getErrorCases()
+    {
+        return [
+            [stream_context_create()],
+            [[stream_context_create()]],
+            [['key' => stream_context_create()]],
+            [new ArrayObject(['key' => stream_context_create()])],
+        ];
+    }
+
+    /** @dataProvider getErrorCases */
+    public function testResourcesAreForbidden($value)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        value_to_key($value);
+    }
+
+    public function testObjectReferencesWithStdClass()
+    {
+        $key1 = value_to_key(new stdClass());
+        $key2 = value_to_key(new stdClass());
+        self::assertNotSame($key1, $key2);
+
+        self::assertSame(
+            1,
+            preg_match(self::createObjectRefRegex('stdClass'), $key1, $key1Matches),
+            'Can extract object hash from key1'
+        );
+        self::assertSame(
+            1,
+            preg_match(self::createObjectRefRegex('stdClass'), $key1, $key2Matches),
+            'Can extract object hash from key2'
+        );
+
+        if (PHP_VERSION_ID >= 70400) {
+            self::assertSame($key1Matches['hash'], $key2Matches['hash'], 'Object hashes match');
+            self::assertSame('[i:0;~stdClass:' . $key1Matches['hash'] . ':0]', $key1, 'Object versions do not match');
+            self::assertSame('[i:0;~stdClass:' . $key1Matches['hash'] . ':1]', $key2, 'Object versions do not match');
+        } else {
+            self::assertNotSame($key1Matches['hash'], $key2Matches['hash'], 'Object hashes don’t match');
+        }
+    }
+
+    public function testObjectReferencesWithArrayObject()
+    {
+        $key1 = value_to_key(new ArrayObject());
+        $key2 = value_to_key(new ArrayObject(['foo' => 'bar']));
+        self::assertNotSame($key1, $key2);
+
+        self::assertSame(
+            1,
+            preg_match(self::createObjectRefRegex('ArrayObject'), $key1, $key1Matches),
+            'Can extract object hash from key1'
+        );
+        self::assertSame(
+            1,
+            preg_match(self::createObjectRefRegex('ArrayObject'), $key1, $key2Matches),
+            'Can extract object hash from key2'
+        );
+
+        if (PHP_VERSION_ID >= 70400) {
+            self::assertSame($key1Matches['hash'], $key2Matches['hash'], 'Object hashes match');
+            self::assertSame('[i:0;~ArrayObject:' . $key1Matches['hash'] . ':2[]]', $key1, 'Object versions do not match');
+            self::assertSame('[i:0;~ArrayObject:' . $key1Matches['hash'] . ':3[s:3:"foo";~s:3:"bar";]]', $key2, 'Object versions do not match');
+        } else {
+            self::assertNotSame($key1Matches['hash'], $key2Matches['hash'], 'Object hashes don’t match');
+        }
+    }
+
+    private static function createObjectRefRegex(string $class = '.*'): string
+    {
+        return sprintf(self::OBJECT_REF_REGEX, $class);
+    }
+}

--- a/tests/Functional/ValueToKeyTest.php
+++ b/tests/Functional/ValueToKeyTest.php
@@ -14,6 +14,7 @@ use ArrayObject;
 use Functional\Exceptions\InvalidArgumentException;
 use PHPUnit\Framework\Constraint\Constraint;
 use stdClass;
+
 use function Functional\ary;
 use function Functional\filter;
 use function Functional\pluck;
@@ -21,6 +22,7 @@ use function Functional\value_to_key;
 use function preg_match;
 use function random_bytes;
 use function stream_context_create;
+
 use const PHP_VERSION_ID;
 
 class ValueToKeyTest extends AbstractTestCase
@@ -66,7 +68,7 @@ class ValueToKeyTest extends AbstractTestCase
     public function testValueToRefOnSimpleTypes(array $input, $constraint)
     {
         $ref = value_to_key(...$input);
-        self::assertThat($ref, $constraint instanceof Constraint ? $constraint: self::identicalTo($constraint));
+        self::assertThat($ref, $constraint instanceof Constraint ? $constraint : self::identicalTo($constraint));
 
         $hash[$ref] = 'value';
         self::assertSame('value', $hash[$ref], 'Ref can be used as an array key');

--- a/tests/Functional/ValueToKeyTest.php
+++ b/tests/Functional/ValueToKeyTest.php
@@ -23,6 +23,7 @@ use function preg_match;
 use function random_bytes;
 use function stream_context_create;
 
+use const NAN;
 use const PHP_VERSION_ID;
 
 class ValueToKeyTest extends AbstractTestCase
@@ -39,6 +40,7 @@ class ValueToKeyTest extends AbstractTestCase
             'null string' => [['null'], '[i:0;~s:4:"null";]'],
             'string' => [['string'], '[i:0;~s:6:"string";]'],
             'integers' => [[12, 123], '[i:0;~i:12;:i:1;~i:123;]'],
+            'funky integers' => [[INF, NAN], '[i:0;~d:INF;:i:1;~d:NAN;]'],
             'integer & float' => [[12, 123.10], '[i:0;~i:12;:i:1;~d:123.1;]'],
             'array of string' => [[['foo', 'bar']], '[i:0;~[i:0;~s:3:"foo";:i:1;~s:3:"bar";]]'],
             'nested array of strings (1)' => [

--- a/tests/Functional/ValueToKeyTest.php
+++ b/tests/Functional/ValueToKeyTest.php
@@ -117,7 +117,7 @@ class ValueToKeyTest extends AbstractTestCase
         );
         self::assertSame(
             1,
-            preg_match(self::createObjectRefRegex('stdClass'), $key1, $key2Matches),
+            preg_match(self::createObjectRefRegex('stdClass'), $key2, $key2Matches),
             'Can extract object hash from key2'
         );
 
@@ -126,7 +126,7 @@ class ValueToKeyTest extends AbstractTestCase
             self::assertSame('[i:0;~stdClass:' . $key1Matches['hash'] . ':0]', $key1, 'Object versions do not match');
             self::assertSame('[i:0;~stdClass:' . $key1Matches['hash'] . ':1]', $key2, 'Object versions do not match');
         } else {
-            self::assertNotSame($key1Matches['hash'], $key2Matches['hash'], 'Object hashes don’t match');
+            self::assertNotSame($key1Matches['hash'], $key2Matches['hash'], 'Object hashes should not match');
         }
     }
 
@@ -143,7 +143,7 @@ class ValueToKeyTest extends AbstractTestCase
         );
         self::assertSame(
             1,
-            preg_match(self::createObjectRefRegex('ArrayObject'), $key1, $key2Matches),
+            preg_match(self::createObjectRefRegex('ArrayObject'), $key2, $key2Matches),
             'Can extract object hash from key2'
         );
 


### PR DESCRIPTION
Fixes a bug with the key generator where early object discarding could lead to hash collisions and therefore to incorrect memoized values.