### PR TITLE
Use array_key_exists on arrays in pick()

### DIFF
--- a/src/Functional/Pick.php
+++ b/src/Functional/Pick.php
@@ -20,7 +20,7 @@ use Functional\Exceptions\InvalidArgumentException;
  * @param ArrayAccess|array $collection
  * @param mixed $index
  * @param mixed $default
- * @param callable $callback Custom function to check if index exists, default function is "isset"
+ * @param callable|null $callback Custom function to check if index exists
  * @return mixed
  * @no-named-arguments
  */
@@ -29,7 +29,7 @@ function pick($collection, $index, $default = null, callable $callback = null)
     InvalidArgumentException::assertArrayAccess($collection, __FUNCTION__, 1);
 
     if ($callback === null) {
-        if (!isset($collection[$index])) {
+        if (!isset($collection[$index]) && (!\is_array($collection) || !\array_key_exists($index, $collection))) {
             return $default;
         }
     } else {

--- a/tests/Functional/PickTest.php
+++ b/tests/Functional/PickTest.php
@@ -71,6 +71,8 @@ class PickTest extends AbstractTestCase
             pick($this->array_1, 'one', 5),
             'Index does exists, should return the corresponding value'
         );
+
+        self::assertNull(pick($this->array_1, 'null-index', 'default'), 'Will handle null correctly');
     }
 
     public function testCustomCallback(): void
@@ -93,8 +95,10 @@ class PickTest extends AbstractTestCase
         $object = new ArrayObject();
 
         $object['test'] = 5;
+        $object['null'] = null;
 
         self::assertSame(5, pick($object, 'test'), 'Key exists');
+        self::assertNull(pick($object, 'null'), 'Key exists');
         self::assertSame(10, pick($object, 'dummy', 10), 'Key does not exists');
     }
 }


### PR DESCRIPTION
Deals with nulls properly and behaves more consistently with `ArrayAccess`

Fixes #217