### PR TITLE
Small changes so tests run smoothly

### DIFF
--- a/src/Functional/Group.php
+++ b/src/Functional/Group.php
@@ -32,6 +32,12 @@ function group($collection, callable $callback)
 
         InvalidArgumentException::assertValidArrayKey($groupKey, __FUNCTION__);
 
+        // Avoid implicit conversion, since float numbers cannot be used as
+        // array keys:
+        if (is_numeric($groupKey)) {
+            $groupKey = intval($groupKey);
+        }
+
         if (!isset($groups[$groupKey])) {
             $groups[$groupKey] = [];
         }

--- a/src/Functional/Sequences/ExponentialSequence.php
+++ b/src/Functional/Sequences/ExponentialSequence.php
@@ -38,28 +38,28 @@ class ExponentialSequence implements Iterator
         $this->percentage = $percentage;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->value;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->value = (int) \round(\pow($this->start * (1 + $this->percentage / 100), $this->times));
         $this->times++;
     }
 
-    public function key()
+    public function key(): mixed
     {
         return null;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->times = 1;
         $this->value = $this->start;

--- a/src/Functional/Sequences/LinearSequence.php
+++ b/src/Functional/Sequences/LinearSequence.php
@@ -34,27 +34,27 @@ class LinearSequence implements Iterator
         $this->amount = $amount;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->value;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->value += $this->amount;
     }
 
-    public function key()
+    public function key(): mixed
     {
         return 0;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->value = $this->start;
     }


### PR DESCRIPTION
A few methods were missing the return type to be compatible with the Iterator interface.

Plus I added an explicit conversion when a float is used as an array key in Group.php.